### PR TITLE
Implement Sign-Out Flow with Animated Logout Icon & Confirmation Dialog

### DIFF
--- a/feature-profile/src/commonMain/kotlin/com/tunjid/heron/profile/ProfileViewModel.kt
+++ b/feature-profile/src/commonMain/kotlin/com/tunjid/heron/profile/ProfileViewModel.kt
@@ -67,6 +67,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.take
 import kotlinx.datetime.Clock
@@ -131,6 +132,9 @@ class ActualProfileViewModel(
                     is Action.Navigate -> action.flow.consumeNavigationActions(
                         navigationMutationConsumer = navActions
                     )
+                    Action.SignOut -> flow {
+                        authRepository.signOut()
+                    }
                 }
             },
             loadSignedInProfileMutations(

--- a/feature-profile/src/commonMain/kotlin/com/tunjid/heron/profile/State.kt
+++ b/feature-profile/src/commonMain/kotlin/com/tunjid/heron/profile/State.kt
@@ -186,4 +186,6 @@ sealed class Action(val key: String) {
             }
         }
     }
+
+    data object SignOut : Action(key = "SignOut")
 }


### PR DESCRIPTION
# ✨ Feature: Implement Sign-Out Flow with Animated Logout Icon & Confirmation Dialog

## 📋 Description
This PR adds a complete sign-out flow to the application, following the design and UX patterns in the challenge requirements.

## 🔄 Changes Included
- **Logout icon** added to the Profile screen header for signed-in users.
- Smooth **fade-out animation** for the logout icon when the profile avatar shifts to the top-right (header collapse) to prevent UI overlap.
- Circular icon styling with theme-based background for visual consistency.
- **ThemedSignOutDialog** styled to match app color scheme, with confirmation step before logging out.
- Sign-out visibility state handled in `ProfileScreen` using `rememberSaveable` to survive configuration changes.
- **Separation of concerns**:
  - UI triggers `onShowSignOutDialog` via header icon click.
  - Dialog triggers `actions(Action.SignOut)` for ViewModel to handle logout logic and navigation.

## 🛠 Flow
1. User taps the **logout icon** in Profile header.  
2. **Confirmation dialog** appears.  
3. On confirmation, **ViewModel** signs the user out and navigates to sign-in screen.  

## 💡 Why This Approach
- **Safe** – Uses a confirmation dialog to prevent accidental sign-outs.  
- **Visible** – Logout icon is clearly placed in the header for signed-in users, no hidden menus.  
- **Quick Access** – Accessible from the profile screen without deep navigation.  
- **Consistent** – Tied to the profile screen, which is the ideal and expected place for account-related actions like signing out.  

## ✅ Testing Steps
1. Sign in to the app.
2. Navigate to **Profile** screen.
3. Tap the **logout icon** → dialog should appear.
4. Tap **"Sign Out"** → user is signed out and redirected to sign-in.
5. Rotate device while dialog is open → dialog remains visible.

## 🎥 Demo Video
[Watch the demo on Loom](https://www.loom.com/share/ca640a3c7e23443b8d99dada62ea1d39)