### PR TITLE
Downgrade to lifecycle 2.9.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "8.12.1"
 android-desugar-jdk-libs = "2.1.5"
-androidx-activityCompose = "1.12.0-alpha02 "
+androidx-activityCompose = "1.12.0-alpha02"
 androidx-appcompat = "1.7.1"
 androidx-constraintlayout = "2.2.1"
 androidx-core-ktx = "1.17.0"
@@ -16,7 +16,9 @@ androidx-room = "2.7.2"
 androidx-sqlite = "2.5.2"
 androidx-espresso-core = "3.7.0"
 javaDiffUtils = "4.16"
-lifecycle = "2.9.2"
+# TODO: Compose runtime crashes when this is bumped
+# Figure out what changed between versions 2.9.1 and 2.9.2
+lifecycle = "2.9.1"
 androidx-material = "1.12.0"
 androidx-test-junit = "1.3.0"
 coil = "3.3.0"


### PR DESCRIPTION
@Goooler I'm not sure what changes between 2.9.1 and 2.9.2, but there's a weird ArrayIndexOutOfBounds excpetion in the compose runtime int brings from this PR: https://github.com/tunjid/heron/pull/360/