### PR TITLE
Protect visibility of SavedStateDataSource methods

### DIFF
--- a/data/core/src/commonMain/kotlin/com/tunjid/heron/data/network/NetworkService.kt
+++ b/data/core/src/commonMain/kotlin/com/tunjid/heron/data/network/NetworkService.kt
@@ -77,9 +77,9 @@ class KtorNetworkService(
                     savedStateDataSource.signedInAuth.first()
                 }
                 this.saveAuth = {
-                    savedStateDataSource.updateState {
-                        copy(auth = it)
-                    }
+                    savedStateDataSource.setAuth(
+                        auth = it
+                    )
                 }
             }
             install(Logging) {

--- a/data/core/src/commonMain/kotlin/com/tunjid/heron/data/network/NetworkService.kt
+++ b/data/core/src/commonMain/kotlin/com/tunjid/heron/data/network/NetworkService.kt
@@ -78,7 +78,7 @@ class KtorNetworkService(
                 }
                 this.saveAuth = {
                     savedStateDataSource.setAuth(
-                        auth = it
+                        auth = it,
                     )
                 }
             }

--- a/data/core/src/commonMain/kotlin/com/tunjid/heron/data/repository/AuthRepository.kt
+++ b/data/core/src/commonMain/kotlin/com/tunjid/heron/data/repository/AuthRepository.kt
@@ -135,7 +135,7 @@ internal class AuthTokenRepository(
 
     override suspend fun signOut() {
         savedStateDataSource.setAuth(
-            auth = null
+            auth = null,
         )
     }
 

--- a/data/core/src/commonMain/kotlin/com/tunjid/heron/data/repository/AuthRepository.kt
+++ b/data/core/src/commonMain/kotlin/com/tunjid/heron/data/repository/AuthRepository.kt
@@ -134,9 +134,9 @@ internal class AuthTokenRepository(
     }
 
     override suspend fun signOut() {
-        savedStateDataSource.updateState {
-            copy(auth = null)
-        }
+        savedStateDataSource.setAuth(
+            auth = null
+        )
     }
 
     override suspend fun updateSignedInUser(): Boolean {

--- a/data/core/src/commonMain/kotlin/com/tunjid/heron/data/repository/SavedStateDataSource.kt
+++ b/data/core/src/commonMain/kotlin/com/tunjid/heron/data/repository/SavedStateDataSource.kt
@@ -165,15 +165,15 @@ fun SavedState.isSignedIn() =
 internal suspend fun SavedStateDataSource.guestSignIn() =
     updateState { copy(auth = GuestAuth) }
 
-sealed class SavedStateDataSource{
-    abstract  val savedState: StateFlow<SavedState>
+sealed class SavedStateDataSource {
+    abstract val savedState: StateFlow<SavedState>
 
     abstract suspend fun setNavigationState(
         navigation: SavedState.Navigation,
     )
 
     internal abstract suspend fun setAuth(
-        auth: SavedState.AuthTokens?
+        auth: SavedState.AuthTokens?,
     )
 
     internal abstract suspend fun updateSignedInUserPreferences(
@@ -217,9 +217,9 @@ internal class DataStoreSavedStateDataSource(
     }
 
     override suspend fun setAuth(auth: SavedState.AuthTokens?) {
-       updateState {
-           copy(auth = auth)
-       }
+        updateState {
+            copy(auth = auth)
+        }
     }
 
     override suspend fun updateSignedInUserPreferences(preferences: Preferences) {

--- a/data/core/src/commonMain/kotlin/com/tunjid/heron/data/repository/SavedStateDataSource.kt
+++ b/data/core/src/commonMain/kotlin/com/tunjid/heron/data/repository/SavedStateDataSource.kt
@@ -165,9 +165,26 @@ fun SavedState.isSignedIn() =
 internal suspend fun SavedStateDataSource.guestSignIn() =
     updateState { copy(auth = GuestAuth) }
 
-interface SavedStateDataSource {
-    val savedState: StateFlow<SavedState>
-    suspend fun updateState(update: SavedState.() -> SavedState)
+sealed class SavedStateDataSource{
+    abstract  val savedState: StateFlow<SavedState>
+
+    abstract suspend fun setNavigationState(
+        navigation: SavedState.Navigation,
+    )
+
+    internal abstract suspend fun setAuth(
+        auth: SavedState.AuthTokens?
+    )
+
+    internal abstract suspend fun updateSignedInUserPreferences(
+        preferences: Preferences,
+    )
+
+    internal abstract suspend fun updateSignedInUserNotifications(
+        block: SavedState.Notifications.() -> SavedState.Notifications,
+    )
+
+    internal abstract suspend fun updateState(update: SavedState.() -> SavedState)
 }
 
 @Inject
@@ -176,7 +193,7 @@ internal class DataStoreSavedStateDataSource(
     fileSystem: FileSystem,
     @Named("AppScope") appScope: CoroutineScope,
     protoBuf: ProtoBuf,
-) : SavedStateDataSource {
+) : SavedStateDataSource() {
 
     private val dataStore: DataStore<SavedState> = DataStoreFactory.create(
         storage = OkioStorage(
@@ -193,6 +210,30 @@ internal class DataStoreSavedStateDataSource(
         initialValue = InitialSavedState,
     )
 
+    override suspend fun setNavigationState(navigation: SavedState.Navigation) {
+        updateState {
+            copy(navigation = navigation)
+        }
+    }
+
+    override suspend fun setAuth(auth: SavedState.AuthTokens?) {
+       updateState {
+           copy(auth = auth)
+       }
+    }
+
+    override suspend fun updateSignedInUserPreferences(preferences: Preferences) {
+        updateSignedInProfileData {
+            copy(preferences = preferences)
+        }
+    }
+
+    override suspend fun updateSignedInUserNotifications(block: SavedState.Notifications.() -> SavedState.Notifications) {
+        updateSignedInProfileData {
+            copy(notifications = notifications.block())
+        }
+    }
+
     override suspend fun updateState(update: SavedState.() -> SavedState) {
         dataStore.updateData(update)
     }
@@ -208,22 +249,6 @@ private class SavedStateOkioSerializer(
 
     override suspend fun writeTo(t: SavedState, sink: BufferedSink) {
         sink.write(protoBuf.encodeToByteArray(value = t))
-    }
-}
-
-internal suspend inline fun SavedStateDataSource.updateSignedInUserPreferences(
-    preferences: Preferences,
-) {
-    updateSignedInProfileData {
-        copy(preferences = preferences)
-    }
-}
-
-internal suspend inline fun SavedStateDataSource.updateSignedInUserNotifications(
-    crossinline block: SavedState.Notifications.() -> SavedState.Notifications,
-) {
-    updateSignedInProfileData {
-        copy(notifications = notifications.block())
     }
 }
 

--- a/scaffold/src/commonMain/kotlin/com/tunjid/heron/scaffold/navigation/NavigationMutator.kt
+++ b/scaffold/src/commonMain/kotlin/com/tunjid/heron/scaffold/navigation/NavigationMutator.kt
@@ -390,7 +390,7 @@ private fun CoroutineScope.persistNavigationState(
     savedStateDataSource: SavedStateDataSource,
 ) = launch {
     if (navigationState != InitialNavigationState) savedStateDataSource.setNavigationState(
-        navigation = navigationState.toSavedState()
+        navigation = navigationState.toSavedState(),
     )
 }
 

--- a/scaffold/src/commonMain/kotlin/com/tunjid/heron/scaffold/navigation/NavigationMutator.kt
+++ b/scaffold/src/commonMain/kotlin/com/tunjid/heron/scaffold/navigation/NavigationMutator.kt
@@ -389,9 +389,9 @@ private fun CoroutineScope.persistNavigationState(
     navigationState: MultiStackNav,
     savedStateDataSource: SavedStateDataSource,
 ) = launch {
-    if (navigationState != InitialNavigationState) savedStateDataSource.updateState {
-        this.copy(navigation = navigationState.toSavedState())
-    }
+    if (navigationState != InitialNavigationState) savedStateDataSource.setNavigationState(
+        navigation = navigationState.toSavedState()
+    )
 }
 
 private fun RouteParser.parseMultiStackNav(savedState: SavedState) =


### PR DESCRIPTION
# PR Description

This PR refactors `SavedStateDataSource` to better enforce **read-only vs write access** between feature modules and the core data layer.

## Key Changes

- **Refactored `SavedStateDataSource`**
  - Converted from an `interface` to a `sealed class`.
  - Introduced `internal abstract suspend fun updateState(...)` as the single low-level write primitive.
  - Restricted mutation methods (`setAuth`, `updateSignedInUserPreferences`, `updateSignedInUserNotifications`) to **internal** scope to ensure only core repositories can modify state.
  - Exposed minimal public API (`setNavigationState`) for controlled navigation updates.

- **Navigation**
  - `NavigationMutator` replaced with `setNavigationState` in `SavedStateDataSource`.
  - Feature modules now use the public `setNavigationState` instead of raw state writes.

- **Auth**
  - Added `guestSignIn()` helper using `updateState { ... }` internally.
  - `AuthRepository.signOut()` now routes through `guestSignIn()` instead of writing directly to state.

- **Notifications**
  - `NotificationsRepository` updated to use the new internal `updateSignedInUserNotifications` mutation API.

## Motivation

- Clearly separates **read-only access** (for feature modules) from **write access** (for repositories in the data layer).
- Prevents feature modules from mutating app state directly.