### PR TITLE
Do not override url during bearer token auth

### DIFF
--- a/data/core/src/commonMain/kotlin/com/tunjid/heron/data/network/SessionManager.kt
+++ b/data/core/src/commonMain/kotlin/com/tunjid/heron/data/network/SessionManager.kt
@@ -255,11 +255,10 @@ internal class PersistedSessionManager @Inject constructor(
     ) = with(context) {
         when (tokens) {
             is SavedState.AuthTokens.Authenticated.Bearer -> {
-                val bearerAuthUrl = Url(tokens.authEndpoint)
-                url.host = bearerAuthUrl.host
                 bearerAuth(token = tokens.auth)
             }
             is SavedState.AuthTokens.Authenticated.DPoP -> {
+                // DPoP requests must always be made to the user's PDS
                 val pdsUrl = Url(tokens.pdsUrl)
                 url.protocol = pdsUrl.protocol
                 url.host = pdsUrl.host


### PR DESCRIPTION
Fixes: https://github.com/tunjid/heron/issues/510

@joelmuraguri, this is the issue you were seeing. It's unique to password auth.