### PR TITLE
Allow for dismissing the pull to refresh indicator for timelines by tapping it

### DIFF
--- a/feature/feed/src/commonMain/kotlin/com/tunjid/heron/feed/FeedScreen.kt
+++ b/feature/feed/src/commonMain/kotlin/com/tunjid/heron/feed/FeedScreen.kt
@@ -27,9 +27,7 @@ import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
 import androidx.compose.foundation.lazy.staggeredgrid.items
 import androidx.compose.foundation.lazy.staggeredgrid.rememberLazyStaggeredGridState
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
-import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -68,6 +66,7 @@ import com.tunjid.heron.tiling.isRefreshing
 import com.tunjid.heron.tiling.tiledItems
 import com.tunjid.heron.timeline.state.TimelineState
 import com.tunjid.heron.timeline.state.TimelineStateHolder
+import com.tunjid.heron.timeline.ui.DismissableRefreshIndicator
 import com.tunjid.heron.timeline.ui.TimelineItem
 import com.tunjid.heron.timeline.ui.avatarSharedElementKey
 import com.tunjid.heron.timeline.ui.effects.TimelineRefreshEffect
@@ -114,7 +113,6 @@ internal fun FeedScreen(
     }
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun FeedTimeline(
     scrollToTopRequestId: String?,
@@ -181,7 +179,7 @@ private fun FeedTimeline(
             )
         },
         indicator = {
-            PullToRefreshDefaults.LoadingIndicator(
+            DismissableRefreshIndicator(
                 modifier = Modifier
                     .align(Alignment.TopCenter)
                     .offset {
@@ -189,6 +187,9 @@ private fun FeedTimeline(
                     },
                 state = pullToRefreshState,
                 isRefreshing = timelineState.isRefreshing,
+                onDismissRequest = {
+                    timelineStateHolder.accept(TimelineState.Action.DismissRefresh)
+                },
             )
         },
     ) {

--- a/feature/home/src/commonMain/kotlin/com/tunjid/heron/home/HomeScreen.kt
+++ b/feature/home/src/commonMain/kotlin/com/tunjid/heron/home/HomeScreen.kt
@@ -34,7 +34,6 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
-import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -84,6 +83,7 @@ import com.tunjid.heron.tiling.isRefreshing
 import com.tunjid.heron.tiling.tiledItems
 import com.tunjid.heron.timeline.state.TimelineState
 import com.tunjid.heron.timeline.state.TimelineStateHolder
+import com.tunjid.heron.timeline.ui.DismissableRefreshIndicator
 import com.tunjid.heron.timeline.ui.TimelineItem
 import com.tunjid.heron.timeline.ui.avatarSharedElementKey
 import com.tunjid.heron.timeline.ui.effects.TimelineRefreshEffect
@@ -318,7 +318,7 @@ private fun HomeTimeline(
             )
         },
         indicator = {
-            PullToRefreshDefaults.LoadingIndicator(
+            DismissableRefreshIndicator(
                 modifier = Modifier
                     .align(Alignment.TopCenter)
                     .offset {
@@ -326,6 +326,9 @@ private fun HomeTimeline(
                     },
                 state = pullToRefreshState,
                 isRefreshing = timelineState.isRefreshing,
+                onDismissRequest = {
+                    timelineStateHolder.accept(TimelineState.Action.DismissRefresh)
+                },
             )
         },
     ) {

--- a/feature/list/src/commonMain/kotlin/com/tunjid/heron/list/ListScreen.kt
+++ b/feature/list/src/commonMain/kotlin/com/tunjid/heron/list/ListScreen.kt
@@ -36,7 +36,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
-import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -80,6 +79,7 @@ import com.tunjid.heron.tiling.isRefreshing
 import com.tunjid.heron.tiling.tiledItems
 import com.tunjid.heron.timeline.state.TimelineState
 import com.tunjid.heron.timeline.state.TimelineStateHolder
+import com.tunjid.heron.timeline.ui.DismissableRefreshIndicator
 import com.tunjid.heron.timeline.ui.TimelineItem
 import com.tunjid.heron.timeline.ui.avatarSharedElementKey
 import com.tunjid.heron.timeline.ui.effects.TimelineRefreshEffect
@@ -154,7 +154,7 @@ internal fun ListScreen(
             updatedStateHolders[pagerState.currentPage].refresh()
         },
         indicator = {
-            PullToRefreshDefaults.LoadingIndicator(
+            DismissableRefreshIndicator(
                 modifier = Modifier
                     .align(Alignment.TopCenter)
                     .offset {
@@ -162,6 +162,14 @@ internal fun ListScreen(
                     },
                 state = pullToRefreshState,
                 isRefreshing = isRefreshing,
+                onDismissRequest = {
+                    when (val holder = updatedStateHolders[pagerState.currentPage]) {
+                        is ListScreenStateHolders.Members -> Unit
+                        is ListScreenStateHolders.Timeline -> holder.accept(
+                            TimelineState.Action.DismissRefresh,
+                        )
+                    }
+                },
             )
         },
     ) {

--- a/feature/notifications/src/commonMain/kotlin/com/tunjid/heron/notifications/NotificationsViewModel.kt
+++ b/feature/notifications/src/commonMain/kotlin/com/tunjid/heron/notifications/NotificationsViewModel.kt
@@ -29,6 +29,7 @@ import com.tunjid.heron.scaffold.navigation.consumeNavigationActions
 import com.tunjid.heron.scaffold.scaffold.duplicateWriteMessage
 import com.tunjid.heron.scaffold.scaffold.failedWriteMessage
 import com.tunjid.heron.tiling.TilingState
+import com.tunjid.heron.tiling.refreshedStatus
 import com.tunjid.heron.tiling.reset
 import com.tunjid.heron.tiling.tilingMutations
 import com.tunjid.mutator.ActionStateMutator
@@ -128,9 +129,7 @@ fun lastRefreshedMutations(
                     is TilingState.Status.Refreshed -> currentStatus
                     is TilingState.Status.Refreshing -> {
                         if (refreshedAt == null || refreshedAt < tilingData.currentQuery.data.cursorAnchor) currentStatus
-                        else TilingState.Status.Refreshed(
-                            cursorAnchor = tilingData.currentQuery.data.cursorAnchor,
-                        )
+                        else tilingData.refreshedStatus()
                     }
                 },
             ),

--- a/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/ui/DismissableRefreshIndicator.kt
+++ b/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/ui/DismissableRefreshIndicator.kt
@@ -1,0 +1,63 @@
+/*
+ *    Copyright 2024 Adetunji Dahunsi
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.tunjid.heron.timeline.ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.offset
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.LoadingIndicatorDefaults
+import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
+import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults.PositionalThreshold
+import androidx.compose.material3.pulltorefresh.PullToRefreshState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.IntOffset
+import kotlin.math.roundToInt
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun DismissableRefreshIndicator(
+    modifier: Modifier = Modifier,
+    state: PullToRefreshState,
+    isRefreshing: Boolean,
+    onDismissRequest: () -> Unit,
+) {
+    val threshold = PositionalThreshold
+    Box(
+        modifier = modifier,
+    ) {
+        PullToRefreshDefaults.LoadingIndicator(
+            state = state,
+            isRefreshing = isRefreshing,
+            threshold = threshold,
+        )
+        Box(
+            modifier = Modifier
+                .matchParentSize()
+                .offset {
+                    val indicatorHeight = LoadingIndicatorDefaults.ContainerHeight.toPx()
+                    val indicatorTranslation = state.distanceFraction * threshold.toPx()
+                    IntOffset(
+                        x = 0,
+                        y = (indicatorTranslation - indicatorHeight).roundToInt(),
+                    )
+                }
+                .clickable { onDismissRequest() },
+        )
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/tunjid/heron/issues/512