### PR TITLE
Simplify signature of NetworkMonitor.runCatchingWithNetworkRetry

### DIFF
--- a/data/core/src/commonMain/kotlin/com/tunjid/heron/data/repository/SavedStateDataSource.kt
+++ b/data/core/src/commonMain/kotlin/com/tunjid/heron/data/repository/SavedStateDataSource.kt
@@ -354,7 +354,8 @@ internal suspend fun SavedStateDataSource.updateSignedInUserNotifications(
 internal suspend inline fun <T> SavedStateDataSource.inCurrentProfileSession(
     crossinline block: suspend (ProfileId?) -> T,
 ): T? {
-    val currentProfileId = savedState.value.signedInProfileId
+    val currentSavedState = savedState.first { it != InitialSavedState }
+    val currentProfileId = currentSavedState.signedInProfileId
     return coroutineScope {
         select {
             async {


### PR DESCRIPTION
* `NetworkMonitor.runCatchingWithNetworkRetry` should not be limited to AtProto calls.
* `SavedStateDataSource.inCurrentProfileSession` should suspend until the actual saved state has been loaded from disk.