### PR TITLE
Remove api field from NetworkService

### DIFF
--- a/data/core/src/commonMain/kotlin/com/tunjid/heron/data/network/NetworkService.kt
+++ b/data/core/src/commonMain/kotlin/com/tunjid/heron/data/network/NetworkService.kt
@@ -29,7 +29,6 @@ import kotlin.time.Duration.Companion.seconds
 import sh.christian.ozone.api.response.AtpResponse
 
 internal interface NetworkService {
-    val api: BlueskyApi
 
     /**
      * Catches network related exceptions and wraps them in a failure result.
@@ -51,7 +50,7 @@ internal class KtorNetworkService(
     sessionManager: SessionManager,
     private val networkMonitor: NetworkMonitor,
 ) : NetworkService {
-    override val api = XrpcBlueskyApi(
+    private val api = XrpcBlueskyApi(
         httpClient = httpClient.config {
             sessionManager.manage(config = this)
         },

--- a/data/core/src/commonMain/kotlin/com/tunjid/heron/data/repository/PostRepository.kt
+++ b/data/core/src/commonMain/kotlin/com/tunjid/heron/data/repository/PostRepository.kt
@@ -765,7 +765,7 @@ private fun CreateRecordResponse.successWithUri(): Pair<Boolean, String> =
 private suspend fun NetworkService.uploadImageBlob(
     data: Source,
 ): Result<Blob> = runCatchingWithMonitoredNetworkRetry {
-    api.uploadBlob(ByteReadChannel(data))
+    uploadBlob(ByteReadChannel(data))
         .map(UploadBlobResponse::blob)
 }
 


### PR DESCRIPTION
This achieves the following:

* Enforces retries with exponential backoff for all bluesky calls.
* Allows for more flexibility in the signature of  `runCatchingWithMonitoredNetworkRetry`. An argument can be added in the future, to default to the active user, or any other user with an active authorized token.