### PR TITLE
use common Share icon instead of ArrowCircleUp

### DIFF
--- a/ui/timeline/src/commonMain/composeResources/values/strings.xml
+++ b/ui/timeline/src/commonMain/composeResources/values/strings.xml
@@ -94,6 +94,7 @@
     <string name="copy_link_to_clipboard">Copy link to clipboard</string>
     <string name="send_via_direct_message">Send via Direct Message</string>
     <string name="share_in_post">Share in a post</string>
+    <string name="share_record">Share record</string>
     <string name="send_icon">Send icon</string>
     <string name="post_author_label">Post author label: %1$s</string>
     <string name="label_source">Label by: %1$s</string>

--- a/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/ui/ShareRecordButton.kt
+++ b/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/ui/ShareRecordButton.kt
@@ -12,7 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import heron.ui.timeline.generated.resources.Res
-import heron.ui.timeline.generated.resources.more_options
+import heron.ui.timeline.generated.resources.share_record
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
@@ -30,7 +30,7 @@ fun ShareRecordButton(
         ) {
             Icon(
                 imageVector = Icons.Rounded.Share,
-                contentDescription = stringResource(Res.string.more_options),
+                contentDescription = stringResource(Res.string.share_record),
                 tint = MaterialTheme.colorScheme.primary,
             )
         }

--- a/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/ui/post/PostInteractions.kt
+++ b/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/ui/post/PostInteractions.kt
@@ -118,7 +118,7 @@ fun PostInteractions(
             paneMovableElementSharedTransitionScope = paneMovableElementSharedTransitionScope,
             onInteraction = onInteraction,
             prefixContent = spacer@{ button ->
-                if (button != PostInteractionButton.MoreOptions) return@spacer
+                if (button != PostInteractionButton.Share) return@spacer
                 if (presentation != Timeline.Presentation.Media.Expanded) return@spacer
 
                 Spacer(Modifier.weight(1f))
@@ -185,7 +185,7 @@ private inline fun PostInteractionsButtons(
                         PostInteractionButton.Like -> button.icon(isChecked = post.viewerStats?.likeUri != null)
                         PostInteractionButton.Repost -> button.icon(isChecked = post.viewerStats?.repostUri != null)
                         PostInteractionButton.Bookmark -> button.icon(isChecked = post.viewerStats.isBookmarked)
-                        PostInteractionButton.MoreOptions -> button.icon(isChecked = false)
+                        PostInteractionButton.Share -> button.icon(isChecked = false)
                     },
                     iconSize = iconSize,
                     orientation = orientation,
@@ -201,7 +201,7 @@ private inline fun PostInteractionsButtons(
                             if (post.repostCount > 0) format(post.repostCount)
                             else ""
                         PostInteractionButton.Bookmark -> ""
-                        PostInteractionButton.MoreOptions -> ""
+                        PostInteractionButton.Share -> ""
                     },
                     tint = when (button) {
                         PostInteractionButton.Comment -> MaterialTheme.colorScheme.outline
@@ -215,13 +215,13 @@ private inline fun PostInteractionsButtons(
                         PostInteractionButton.Bookmark ->
                             if (post.viewerStats.isBookmarked) BookmarkBlue
                             else MaterialTheme.colorScheme.outline
-                        PostInteractionButton.MoreOptions -> MaterialTheme.colorScheme.outline
+                        PostInteractionButton.Share -> MaterialTheme.colorScheme.outline
                     },
                     enabled = when (button) {
                         PostInteractionButton.Bookmark -> true
                         PostInteractionButton.Comment -> post.viewerStats.canReply
                         PostInteractionButton.Like -> true
-                        PostInteractionButton.MoreOptions -> true
+                        PostInteractionButton.Share -> true
                         PostInteractionButton.Repost -> true
                     },
                     onClick = {
@@ -277,7 +277,7 @@ private inline fun PostInteractionsButtons(
                                     post.viewerStats,
                                 ),
                             )
-                            PostInteractionButton.MoreOptions -> onInteraction(
+                            PostInteractionButton.Share -> onInteraction(
                                 PostAction.OfMore(post),
                             )
                         }
@@ -565,7 +565,7 @@ private sealed class PostInteractionButton {
     data object Repost : PostInteractionButton()
     data object Like : PostInteractionButton()
     data object Bookmark : PostInteractionButton()
-    data object MoreOptions : PostInteractionButton()
+    data object Share : PostInteractionButton()
 
     companion object {
         fun PostInteractionButton.icon(
@@ -575,7 +575,7 @@ private sealed class PostInteractionButton {
             Like -> if (isChecked) Icons.Rounded.Favorite else Icons.Rounded.FavoriteBorder
             Repost -> Icons.Rounded.Repeat
             Bookmark -> if (isChecked) Icons.Rounded.Bookmark else Icons.Rounded.BookmarkBorder
-            MoreOptions -> Icons.Rounded.Share
+            Share -> Icons.Rounded.Share
         }
 
         val PostInteractionButton.stringResource
@@ -584,7 +584,7 @@ private sealed class PostInteractionButton {
                 Like -> Res.string.liked
                 Repost -> Res.string.repost
                 Bookmark -> Res.string.bookmarked
-                MoreOptions -> Res.string.expand_options
+                Share -> Res.string.expand_options
             }
 
         val PostButtons = listOf(
@@ -592,7 +592,7 @@ private sealed class PostInteractionButton {
             Repost,
             Like,
             Bookmark,
-            MoreOptions,
+            Share,
         )
 
         val MediaButtons = listOf(
@@ -600,7 +600,7 @@ private sealed class PostInteractionButton {
             Comment,
             Repost,
             Bookmark,
-            MoreOptions,
+            Share,
         )
     }
 }


### PR DESCRIPTION
This change could be considered subjective, but not many people know on first glance that the ArrowCircleUp icon indicates sharing, while the Share icon is instantly recognized as a "share" action.