### PR TITLE
fix: smaller strings for dynamic theme setting

### DIFF
--- a/feature/settings/src/commonMain/composeResources/values/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values/strings.xml
@@ -31,6 +31,6 @@
     <string name="refresh_timelines_on_launch">Refresh timelines on launch</string>
     <string name="moderation">Moderation</string>
     <string name="appearance">Appearance</string>
-    <string name="use_dynamic_theming">Use app theme from wallpaper color</string>
+    <string name="use_dynamic_theming">Use device theme from wallpaper color</string>
     <string name="use_compact_navigation">Use compact bottom navigation bar</string>
 </resources>


### PR DESCRIPTION
Fixes this:

<img width="1080" height="379" alt="image" src="https://github.com/user-attachments/assets/b1ec6bb1-29c0-4ca2-9852-0c06f2b95c46" />
