### PR TITLE
fix: actual compact navbar height

### DIFF
--- a/ui/core/src/commonMain/kotlin/com/tunjid/heron/ui/Tokens.kt
+++ b/ui/core/src/commonMain/kotlin/com/tunjid/heron/ui/Tokens.kt
@@ -61,7 +61,7 @@ object UiTokens {
 
     fun bottomNavHeight(
         isCompact: Boolean,
-    ): Dp = if (isCompact) 64.dp else 80.dp
+    ): Dp = if (isCompact) 48.dp else 80.dp
 
     @Composable
     fun bottomNavAndInsetPaddingValues(


### PR DESCRIPTION
| Before | After |
|--------|--------|
| <img width="1080" height="2424" alt="image" src="https://github.com/user-attachments/assets/ac14c0ed-0cc2-4e8a-b4ab-e6dc0bfc7f10" /> | <img width="1080" height="2424" alt="image" src="https://github.com/user-attachments/assets/dd5bae00-5869-46ff-be09-5c101525296c" /> | 