### PR TITLE
fix: use correct scroll direction for value change for post btn

### DIFF
--- a/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/ui/post/PostInteractions.kt
+++ b/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/ui/post/PostInteractions.kt
@@ -678,18 +678,18 @@ private sealed class PostInteractionButton {
 
         val TextCheckedTransform = slideInVertically(
             animationSpec = TextAnimationSpec,
-            initialOffsetY = { -it },
-        ) togetherWith slideOutVertically(
-            animationSpec = TextAnimationSpec,
-            targetOffsetY = { it },
-        )
-
-        val TextUncheckedTransform = slideInVertically(
-            animationSpec = TextAnimationSpec,
             initialOffsetY = { it },
         ) togetherWith slideOutVertically(
             animationSpec = TextAnimationSpec,
             targetOffsetY = { -it },
+        )
+
+        val TextUncheckedTransform = slideInVertically(
+            animationSpec = TextAnimationSpec,
+            initialOffsetY = { -it },
+        ) togetherWith slideOutVertically(
+            animationSpec = TextAnimationSpec,
+            targetOffsetY = { it },
         )
 
         fun buttonText(


### PR DESCRIPTION
This fixes the number scrolling down when the value went up and vice versa.