### PR TITLE
Add/Remove Profile from Lists

### DIFF
--- a/data/core/src/commonMain/kotlin/com/tunjid/heron/data/repository/ProfileRepository.kt
+++ b/data/core/src/commonMain/kotlin/com/tunjid/heron/data/repository/ProfileRepository.kt
@@ -40,7 +40,6 @@ import com.tunjid.heron.data.core.models.Cursor
 import com.tunjid.heron.data.core.models.CursorList
 import com.tunjid.heron.data.core.models.CursorQuery
 import com.tunjid.heron.data.core.models.DataQuery
-import com.tunjid.heron.data.core.models.ListMember
 import com.tunjid.heron.data.core.models.Profile
 import com.tunjid.heron.data.core.models.ProfileViewerState
 import com.tunjid.heron.data.core.models.ProfileWithViewerState
@@ -48,7 +47,6 @@ import com.tunjid.heron.data.core.models.value
 import com.tunjid.heron.data.core.types.BlockUri
 import com.tunjid.heron.data.core.types.FollowUri
 import com.tunjid.heron.data.core.types.Id
-import com.tunjid.heron.data.core.types.ProfileId
 import com.tunjid.heron.data.core.types.RecordCreationException
 import com.tunjid.heron.data.core.types.Uri
 import com.tunjid.heron.data.core.types.recordKey
@@ -114,10 +112,6 @@ interface ProfileRepository {
         limit: Long,
     ): Flow<List<Profile>>
 
-    fun membershipsByProfile(
-        profileId: ProfileId,
-    ): Flow<List<ListMember>>
-
     fun followers(
         query: ProfilesQuery,
         cursor: Cursor,
@@ -153,7 +147,6 @@ interface ProfileRepository {
 internal class OfflineProfileRepository @Inject constructor(
     @param:IODispatcher
     private val ioDispatcher: CoroutineDispatcher,
-    private val listDao: ListDao,
     private val profileDao: ProfileDao,
     private val profileLookup: ProfileLookup,
     private val networkService: NetworkService,
@@ -219,22 +212,6 @@ internal class OfflineProfileRepository @Inject constructor(
             )
                 .distinctUntilChangedMap { profileEntities ->
                     profileEntities.map(PopulatedProfileEntity::asExternalModel)
-                }
-        }
-            .flowOn(ioDispatcher)
-
-    override fun membershipsByProfile(
-        profileId: ProfileId,
-    ): Flow<List<ListMember>> =
-        savedStateDataSource.singleAuthorizedSessionFlow { signedInProfileId ->
-            if (profileId.id.isEmpty()) return@singleAuthorizedSessionFlow emptyFlow<List<ListMember>>()
-
-            listDao.membershipsByProfile(
-                profileId = profileId.id,
-                signedInUserId = signedInProfileId.id,
-            )
-                .distinctUntilChangedMap { entities ->
-                    entities.map { it.asExternalModel() }
                 }
         }
             .flowOn(ioDispatcher)

--- a/data/core/src/commonMain/kotlin/com/tunjid/heron/data/repository/ProfileRepository.kt
+++ b/data/core/src/commonMain/kotlin/com/tunjid/heron/data/repository/ProfileRepository.kt
@@ -40,6 +40,7 @@ import com.tunjid.heron.data.core.models.Cursor
 import com.tunjid.heron.data.core.models.CursorList
 import com.tunjid.heron.data.core.models.CursorQuery
 import com.tunjid.heron.data.core.models.DataQuery
+import com.tunjid.heron.data.core.models.ListMember
 import com.tunjid.heron.data.core.models.Profile
 import com.tunjid.heron.data.core.models.ProfileViewerState
 import com.tunjid.heron.data.core.models.ProfileWithViewerState
@@ -47,10 +48,12 @@ import com.tunjid.heron.data.core.models.value
 import com.tunjid.heron.data.core.types.BlockUri
 import com.tunjid.heron.data.core.types.FollowUri
 import com.tunjid.heron.data.core.types.Id
+import com.tunjid.heron.data.core.types.ProfileId
 import com.tunjid.heron.data.core.types.RecordCreationException
 import com.tunjid.heron.data.core.types.Uri
 import com.tunjid.heron.data.core.types.recordKey
 import com.tunjid.heron.data.core.utilities.Outcome
+import com.tunjid.heron.data.database.daos.ListDao
 import com.tunjid.heron.data.database.daos.ProfileDao
 import com.tunjid.heron.data.database.entities.PopulatedProfileEntity
 import com.tunjid.heron.data.database.entities.asExternalModel
@@ -111,6 +114,10 @@ interface ProfileRepository {
         limit: Long,
     ): Flow<List<Profile>>
 
+    fun membershipsByProfile(
+        profileId: ProfileId,
+    ): Flow<List<ListMember>>
+
     fun followers(
         query: ProfilesQuery,
         cursor: Cursor,
@@ -146,6 +153,7 @@ interface ProfileRepository {
 internal class OfflineProfileRepository @Inject constructor(
     @param:IODispatcher
     private val ioDispatcher: CoroutineDispatcher,
+    private val listDao: ListDao,
     private val profileDao: ProfileDao,
     private val profileLookup: ProfileLookup,
     private val networkService: NetworkService,
@@ -211,6 +219,21 @@ internal class OfflineProfileRepository @Inject constructor(
             )
                 .distinctUntilChangedMap { profileEntities ->
                     profileEntities.map(PopulatedProfileEntity::asExternalModel)
+                }
+        }
+            .flowOn(ioDispatcher)
+
+    override fun membershipsByProfile(
+        profileId: ProfileId,
+    ): Flow<List<ListMember>> =
+        savedStateDataSource.singleAuthorizedSessionFlow { _ ->
+            if (profileId.id.isEmpty()) return@singleAuthorizedSessionFlow emptyFlow<List<ListMember>>()
+
+            listDao.membershipsByProfile(
+                profileId = profileId.id,
+            )
+                .distinctUntilChangedMap { entities ->
+                    entities.map { it.asExternalModel() }
                 }
         }
             .flowOn(ioDispatcher)

--- a/data/core/src/commonMain/kotlin/com/tunjid/heron/data/repository/ProfileRepository.kt
+++ b/data/core/src/commonMain/kotlin/com/tunjid/heron/data/repository/ProfileRepository.kt
@@ -226,11 +226,12 @@ internal class OfflineProfileRepository @Inject constructor(
     override fun membershipsByProfile(
         profileId: ProfileId,
     ): Flow<List<ListMember>> =
-        savedStateDataSource.singleAuthorizedSessionFlow { _ ->
+        savedStateDataSource.singleAuthorizedSessionFlow { signedInProfileId ->
             if (profileId.id.isEmpty()) return@singleAuthorizedSessionFlow emptyFlow<List<ListMember>>()
 
             listDao.membershipsByProfile(
                 profileId = profileId.id,
+                signedInUserId = signedInProfileId.id,
             )
                 .distinctUntilChangedMap { entities ->
                     entities.map { it.asExternalModel() }

--- a/data/core/src/commonMain/kotlin/com/tunjid/heron/data/repository/RecordRepository.kt
+++ b/data/core/src/commonMain/kotlin/com/tunjid/heron/data/repository/RecordRepository.kt
@@ -111,7 +111,7 @@ internal class OfflineFirstRecordRepository @Inject constructor(
                     // reuses createdListMembers which saves into listMembers table
                     createdListMembers(
                         query = CreatedListMembersQuery(
-                            profileId = signedInProfileId,
+                            profileId = profileId,
                             data = CursorQuery.Data(
                                 page = 0,
                                 cursorAnchor = Clock.System.now(),

--- a/data/core/src/commonMain/kotlin/com/tunjid/heron/data/repository/RecordRepository.kt
+++ b/data/core/src/commonMain/kotlin/com/tunjid/heron/data/repository/RecordRepository.kt
@@ -16,7 +16,6 @@
 
 package com.tunjid.heron.data.repository
 
-import com.tunjid.heron.data.core.models.Cursor
 import com.tunjid.heron.data.core.models.CursorQuery
 import com.tunjid.heron.data.core.models.ListMember
 import com.tunjid.heron.data.core.models.Record
@@ -45,18 +44,15 @@ import com.tunjid.heron.data.utilities.distinctUntilChangedMap
 import com.tunjid.heron.data.utilities.recordResolver.RecordResolver
 import com.tunjid.heron.data.utilities.withRefresh
 import dev.zacsweers.metro.Inject
-import kotlin.time.Clock
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class CreatedListMembersQuery(
-    val profileId: ProfileId,
     override val data: CursorQuery.Data,
 ) : CursorQuery
 
@@ -105,21 +101,6 @@ internal class OfflineFirstRecordRepository @Inject constructor(
             )
                 .distinctUntilChangedMap { entities ->
                     entities.map { it.asExternalModel() }
-                }
-                .withRefresh {
-                    // Trigger a network fetch to populate the DB
-                    // reuses createdListMembers which saves into listMembers table
-                    createdListMembers(
-                        query = CreatedListMembersQuery(
-                            profileId = profileId,
-                            data = CursorQuery.Data(
-                                page = 0,
-                                cursorAnchor = Clock.System.now(),
-                                limit = 15,
-                            ),
-                        ),
-                        cursor = Cursor.Initial,
-                    ).first()
                 }
         }
             .flowOn(ioDispatcher)

--- a/data/core/src/commonMain/kotlin/com/tunjid/heron/data/repository/RecordRepository.kt
+++ b/data/core/src/commonMain/kotlin/com/tunjid/heron/data/repository/RecordRepository.kt
@@ -16,12 +16,16 @@
 
 package com.tunjid.heron.data.repository
 
+import com.tunjid.heron.data.core.models.Cursor
+import com.tunjid.heron.data.core.models.CursorQuery
+import com.tunjid.heron.data.core.models.ListMember
 import com.tunjid.heron.data.core.models.Record
 import com.tunjid.heron.data.core.types.EmbeddableRecordUri
 import com.tunjid.heron.data.core.types.FeedGeneratorUri
 import com.tunjid.heron.data.core.types.LabelerUri
 import com.tunjid.heron.data.core.types.ListUri
 import com.tunjid.heron.data.core.types.PostUri
+import com.tunjid.heron.data.core.types.ProfileId
 import com.tunjid.heron.data.core.types.RecordUri
 import com.tunjid.heron.data.core.types.StarterPackUri
 import com.tunjid.heron.data.core.types.UnauthorizedException
@@ -41,14 +45,28 @@ import com.tunjid.heron.data.utilities.distinctUntilChangedMap
 import com.tunjid.heron.data.utilities.recordResolver.RecordResolver
 import com.tunjid.heron.data.utilities.withRefresh
 import dev.zacsweers.metro.Inject
+import kotlin.time.Clock
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CreatedListMembersQuery(
+    val profileId: ProfileId,
+    override val data: CursorQuery.Data,
+) : CursorQuery
 
 interface RecordRepository :
     BlueskyRecordOperations,
     StandardSiteRecordOperations {
+
+    fun listMembersByProfile(
+        profileId: ProfileId,
+    ): Flow<List<ListMember>>
 
     fun embeddableRecord(
         uri: EmbeddableRecordUri,
@@ -74,6 +92,37 @@ internal class OfflineFirstRecordRepository @Inject constructor(
 ) : RecordRepository,
     BlueskyRecordOperations by blueskyRecordOperations,
     StandardSiteRecordOperations by standardSiteRecordOperations {
+
+    override fun listMembersByProfile(
+        profileId: ProfileId,
+    ): Flow<List<ListMember>> =
+        savedStateDataSource.singleAuthorizedSessionFlow { signedInProfileId ->
+            if (profileId.id.isEmpty()) return@singleAuthorizedSessionFlow emptyFlow<List<ListMember>>()
+
+            listDao.listMembersByProfile(
+                profileId = profileId.id,
+                signedInUserId = signedInProfileId.id,
+            )
+                .distinctUntilChangedMap { entities ->
+                    entities.map { it.asExternalModel() }
+                }
+                .withRefresh {
+                    // Trigger a network fetch to populate the DB
+                    // reuses createdListMembers which saves into listMembers table
+                    createdListMembers(
+                        query = CreatedListMembersQuery(
+                            profileId = signedInProfileId,
+                            data = CursorQuery.Data(
+                                page = 0,
+                                cursorAnchor = Clock.System.now(),
+                                limit = 15,
+                            ),
+                        ),
+                        cursor = Cursor.Initial,
+                    ).first()
+                }
+        }
+            .flowOn(ioDispatcher)
 
     override fun embeddableRecord(uri: EmbeddableRecordUri): Flow<Record.Embeddable> =
         when (uri) {

--- a/data/core/src/commonMain/kotlin/com/tunjid/heron/data/repository/records/BlueskyRecordOperations.kt
+++ b/data/core/src/commonMain/kotlin/com/tunjid/heron/data/repository/records/BlueskyRecordOperations.kt
@@ -31,6 +31,8 @@ import app.bsky.graph.Listitem
 import com.atproto.repo.CreateRecordRequest
 import com.atproto.repo.DeleteRecordRequest
 import com.atproto.repo.GetRecordQueryParams
+import com.atproto.repo.ListRecordsQueryParams
+import com.atproto.repo.ListRecordsResponse
 import com.atproto.repo.PutRecordRequest
 import com.tunjid.heron.data.core.models.Cursor
 import com.tunjid.heron.data.core.models.CursorList
@@ -69,6 +71,7 @@ import com.tunjid.heron.data.graze.GrazeFeed
 import com.tunjid.heron.data.network.FeedCreationService
 import com.tunjid.heron.data.network.GrazeResponse
 import com.tunjid.heron.data.network.NetworkService
+import com.tunjid.heron.data.repository.CreatedListMembersQuery
 import com.tunjid.heron.data.repository.ListMemberQuery
 import com.tunjid.heron.data.repository.ProfilesQuery
 import com.tunjid.heron.data.repository.SavedStateDataSource
@@ -133,6 +136,10 @@ interface BlueskyRecordOperations {
         cursor: Cursor,
     ): Flow<CursorList<ListMember>>
 
+    fun createdListMembers(
+        query: CreatedListMembersQuery,
+        cursor: Cursor,
+    ): Flow<CursorList<ListMember>>
     fun feedGenerators(
         query: ProfilesQuery,
         cursor: Cursor,
@@ -346,6 +353,50 @@ internal class OfflineFirstBlueskyRecordOperations @Inject constructor(
                                 add(
                                     listUri = list.uri.atUri.let(::ListUri),
                                     listItemView = listItemView,
+                                )
+                            }
+                        }
+                    },
+                ),
+                ::CursorList,
+            )
+                .distinctUntilChanged()
+        }
+            .flowOn(ioDispatcher)
+
+    override fun createdListMembers(
+        query: CreatedListMembersQuery,
+        cursor: Cursor,
+    ): Flow<CursorList<ListMember>> =
+        savedStateDataSource.singleAuthorizedSessionFlow { signedInProfileId ->
+            combine(
+                listDao.listMembersByProfile(
+                    profileId = query.profileId.id,
+                    signedInUserId = signedInProfileId.id,
+                )
+                    .distinctUntilChangedMap { entities ->
+                        entities.map(PopulatedListMemberEntity::asExternalModel)
+                    },
+                networkService.nextCursorFlow(
+                    currentCursor = cursor,
+                    currentRequestWithNextCursor = {
+                        listRecords(
+                            ListRecordsQueryParams(
+                                repo = Did(signedInProfileId.id),
+                                collection = Nsid("app.bsky.graph.listitem"),
+                                limit = query.data.limit,
+                                cursor = cursor.value,
+                            ),
+                        )
+                    },
+                    nextCursor = ListRecordsResponse::cursor,
+                    onResponse = {
+                        multipleEntitySaverProvider.saveInTransaction {
+                            records.forEach { record ->
+                                val listItem = record.value.decodeAs<Listitem>()
+                                add(
+                                    listMemberUri = ListMemberUri(record.uri.atUri),
+                                    listItem = listItem,
                                 )
                             }
                         }

--- a/data/core/src/commonMain/kotlin/com/tunjid/heron/data/repository/records/BlueskyRecordOperations.kt
+++ b/data/core/src/commonMain/kotlin/com/tunjid/heron/data/repository/records/BlueskyRecordOperations.kt
@@ -135,11 +135,6 @@ interface BlueskyRecordOperations {
         query: ListMemberQuery,
         cursor: Cursor,
     ): Flow<CursorList<ListMember>>
-
-    fun createdListMembers(
-        query: CreatedListMembersQuery,
-        cursor: Cursor,
-    ): Flow<CursorList<ListMember>>
     fun feedGenerators(
         query: ProfilesQuery,
         cursor: Cursor,
@@ -151,6 +146,10 @@ interface BlueskyRecordOperations {
 
     suspend fun addListMember(
         create: ListMember.Create,
+    ): Outcome
+
+    suspend fun updateCreatedListMembers(
+        signedInProfileId: ProfileId,
     ): Outcome
 }
 
@@ -364,49 +363,6 @@ internal class OfflineFirstBlueskyRecordOperations @Inject constructor(
         }
             .flowOn(ioDispatcher)
 
-    override fun createdListMembers(
-        query: CreatedListMembersQuery,
-        cursor: Cursor,
-    ): Flow<CursorList<ListMember>> =
-        savedStateDataSource.singleAuthorizedSessionFlow { signedInProfileId ->
-            combine(
-                listDao.listMembersCreatedByProfile(
-                    signedInUserId = signedInProfileId.id,
-                )
-                    .distinctUntilChangedMap { entities ->
-                        entities.map(PopulatedListMemberEntity::asExternalModel)
-                    },
-                networkService.nextCursorFlow(
-                    currentCursor = cursor,
-                    currentRequestWithNextCursor = {
-                        listRecords(
-                            ListRecordsQueryParams(
-                                repo = Did(signedInProfileId.id),
-                                collection = Nsid(ListMemberUri.NAMESPACE),
-                                limit = query.data.limit,
-                                cursor = cursor.value,
-                            ),
-                        )
-                    },
-                    nextCursor = ListRecordsResponse::cursor,
-                    onResponse = {
-                        multipleEntitySaverProvider.saveInTransaction {
-                            records.forEach { record ->
-                                val listItem = record.value.decodeAs<Listitem>()
-                                add(
-                                    listMemberUri = ListMemberUri(record.uri.atUri),
-                                    listItem = listItem,
-                                )
-                            }
-                        }
-                    },
-                ),
-                ::CursorList,
-            )
-                .distinctUntilChanged()
-        }
-            .flowOn(ioDispatcher)
-
     override fun feedGenerators(
         query: ProfilesQuery,
         cursor: Cursor,
@@ -553,6 +509,46 @@ internal class OfflineFirstBlueskyRecordOperations @Inject constructor(
         }
             .toOutcome()
     } ?: expiredSessionOutcome()
+
+    override suspend fun updateCreatedListMembers(
+        signedInProfileId: ProfileId,
+    ): Outcome = try {
+        var currentCursor: Cursor = Cursor.Initial
+
+        networkService.nextCursorFlow(
+            currentCursor = currentCursor,
+            currentRequestWithNextCursor = {
+                listRecords(
+                    ListRecordsQueryParams(
+                        repo = Did(signedInProfileId.id),
+                        collection = Nsid(ListMemberUri.NAMESPACE),
+                        limit = 100,
+                        cursor = currentCursor.value,
+                    ),
+                )
+            },
+            nextCursor = ListRecordsResponse::cursor,
+            onResponse = {
+                multipleEntitySaverProvider.saveInTransaction {
+                    records.forEach { record ->
+                        val listItem = record.value.decodeAs<Listitem>()
+                        add(
+                            listMemberUri = ListMemberUri(record.uri.atUri),
+                            listItem = listItem,
+                        )
+                    }
+                }
+            },
+        ).collect { next ->
+            // Update the cursor for the next iteration if needed
+            currentCursor = next
+            // If the flow emits Cursor.Final or we've reached the end, the flow finishes.
+        }
+
+        Outcome.Success
+    } catch (e: Exception) {
+        e.asFailureOutcome()
+    }
 }
 
 private suspend fun NetworkService.updateFeedRecord(

--- a/data/core/src/commonMain/kotlin/com/tunjid/heron/data/repository/records/BlueskyRecordOperations.kt
+++ b/data/core/src/commonMain/kotlin/com/tunjid/heron/data/repository/records/BlueskyRecordOperations.kt
@@ -383,7 +383,7 @@ internal class OfflineFirstBlueskyRecordOperations @Inject constructor(
                         listRecords(
                             ListRecordsQueryParams(
                                 repo = Did(signedInProfileId.id),
-                                collection = Nsid("app.bsky.graph.listitem"),
+                                collection = Nsid(ListMemberUri.NAMESPACE),
                                 limit = query.data.limit,
                                 cursor = cursor.value,
                             ),

--- a/data/core/src/commonMain/kotlin/com/tunjid/heron/data/repository/records/BlueskyRecordOperations.kt
+++ b/data/core/src/commonMain/kotlin/com/tunjid/heron/data/repository/records/BlueskyRecordOperations.kt
@@ -370,8 +370,7 @@ internal class OfflineFirstBlueskyRecordOperations @Inject constructor(
     ): Flow<CursorList<ListMember>> =
         savedStateDataSource.singleAuthorizedSessionFlow { signedInProfileId ->
             combine(
-                listDao.listMembersByProfile(
-                    profileId = query.profileId.id,
+                listDao.listMembersCreatedByProfile(
                     signedInUserId = signedInProfileId.id,
                 )
                     .distinctUntilChangedMap { entities ->

--- a/data/core/src/commonMain/kotlin/com/tunjid/heron/data/utilities/multipleEntitysaver/SaveListItemView.kt
+++ b/data/core/src/commonMain/kotlin/com/tunjid/heron/data/utilities/multipleEntitysaver/SaveListItemView.kt
@@ -45,11 +45,12 @@ internal fun MultipleEntitySaver.add(
     listMemberUri: ListMemberUri,
     listItem: Listitem,
 ) {
+    add(stubProfileEntity(listItem.subject))
     add(
         ListMemberEntity(
             uri = listMemberUri,
-            listUri = ListUri(listItem.list.atUri),
-            subjectId = ProfileId(listItem.subject.did),
+            listUri = listItem.list.atUri.let(::ListUri),
+            subjectId = listItem.subject.did.let(::ProfileId),
             createdAt = listItem.createdAt,
         ),
     )

--- a/data/core/src/commonMain/kotlin/com/tunjid/heron/data/utilities/multipleEntitysaver/SaveListItemView.kt
+++ b/data/core/src/commonMain/kotlin/com/tunjid/heron/data/utilities/multipleEntitysaver/SaveListItemView.kt
@@ -17,6 +17,7 @@
 package com.tunjid.heron.data.utilities.multipleEntitysaver
 
 import app.bsky.graph.ListItemView
+import app.bsky.graph.Listitem
 import com.tunjid.heron.data.core.types.ListMemberUri
 import com.tunjid.heron.data.core.types.ListUri
 import com.tunjid.heron.data.core.types.ProfileId
@@ -36,6 +37,20 @@ internal fun MultipleEntitySaver.add(
             uri = listItemView.uri.atUri.let(::ListMemberUri),
             subjectId = listItemView.subject.did.did.let(::ProfileId),
             createdAt = createdAt,
+        ),
+    )
+}
+
+internal fun MultipleEntitySaver.add(
+    listMemberUri: ListMemberUri,
+    listItem: Listitem,
+) {
+    add(
+        ListMemberEntity(
+            uri = listMemberUri,
+            listUri = ListUri(listItem.list.atUri),
+            subjectId = ProfileId(listItem.subject.did),
+            createdAt = listItem.createdAt,
         ),
     )
 }

--- a/data/core/src/commonMain/kotlin/com/tunjid/heron/data/utilities/writequeue/Writable.kt
+++ b/data/core/src/commonMain/kotlin/com/tunjid/heron/data/utilities/writequeue/Writable.kt
@@ -24,6 +24,7 @@ import com.tunjid.heron.data.core.models.Profile
 import com.tunjid.heron.data.core.models.StandardSubscription
 import com.tunjid.heron.data.core.models.Timeline
 import com.tunjid.heron.data.core.models.sourceId
+import com.tunjid.heron.data.core.types.ProfileId
 import com.tunjid.heron.data.core.types.RecordUri
 import com.tunjid.heron.data.core.utilities.Outcome
 import kotlin.time.Instant
@@ -126,6 +127,18 @@ sealed interface Writable {
 
             override suspend fun WriteQueue.write(): Outcome =
                 recordRepository.addListMember(create)
+        }
+
+        @Serializable
+        data class UpdateCreatedListMembers(
+            val signedInProfileId: ProfileId,
+        ) : FeedList,
+            Writable {
+            override val queueId: String
+                get() = "update-list-members-${signedInProfileId.id}"
+
+            override suspend fun WriteQueue.write(): Outcome =
+                recordRepository.updateCreatedListMembers(signedInProfileId)
         }
     }
 

--- a/data/database/src/commonMain/kotlin/com/tunjid/heron/data/database/daos/ListDao.kt
+++ b/data/database/src/commonMain/kotlin/com/tunjid/heron/data/database/daos/ListDao.kt
@@ -109,6 +109,18 @@ interface ListDao {
         """
         SELECT lm.* FROM listMembers lm
         JOIN lists l ON lm.listUri = l.uri
+        WHERE l.creatorId = :signedInUserId
+    """,
+    )
+    fun listMembersCreatedByProfile(
+        signedInUserId: String,
+    ): Flow<List<PopulatedListMemberEntity>>
+
+    @Transaction
+    @Query(
+        """
+        SELECT lm.* FROM listMembers lm
+        JOIN lists l ON lm.listUri = l.uri
         WHERE lm.subjectId = :profileId
         AND l.creatorId = :signedInUserId
     """,

--- a/data/database/src/commonMain/kotlin/com/tunjid/heron/data/database/daos/ListDao.kt
+++ b/data/database/src/commonMain/kotlin/com/tunjid/heron/data/database/daos/ListDao.kt
@@ -107,12 +107,15 @@ interface ListDao {
     @Transaction
     @Query(
         """
-        SELECT * FROM listMembers
-        WHERE subjectId = :profileId
+        SELECT lm.* FROM listMembers lm
+        JOIN lists l ON lm.listUri = l.uri
+        WHERE lm.subjectId = :profileId
+        AND l.creatorId = :signedInUserId
     """,
     )
     fun membershipsByProfile(
         profileId: String,
+        signedInUserId: String,
     ): Flow<List<PopulatedListMemberEntity>>
 
     @Transaction

--- a/data/database/src/commonMain/kotlin/com/tunjid/heron/data/database/daos/ListDao.kt
+++ b/data/database/src/commonMain/kotlin/com/tunjid/heron/data/database/daos/ListDao.kt
@@ -107,6 +107,17 @@ interface ListDao {
     @Transaction
     @Query(
         """
+        SELECT * FROM listMembers
+        WHERE subjectId = :profileId
+    """,
+    )
+    fun membershipsByProfile(
+        profileId: String,
+    ): Flow<List<PopulatedListMemberEntity>>
+
+    @Transaction
+    @Query(
+        """
             SELECT * FROM lists
 	        WHERE creatorId = :creatorId
             ORDER BY indexedAt

--- a/data/database/src/commonMain/kotlin/com/tunjid/heron/data/database/daos/ListDao.kt
+++ b/data/database/src/commonMain/kotlin/com/tunjid/heron/data/database/daos/ListDao.kt
@@ -113,7 +113,7 @@ interface ListDao {
         AND l.creatorId = :signedInUserId
     """,
     )
-    fun membershipsByProfile(
+    fun listMembersByProfile(
         profileId: String,
         signedInUserId: String,
     ): Flow<List<PopulatedListMemberEntity>>

--- a/data/database/src/commonMain/kotlin/com/tunjid/heron/data/database/daos/ListDao.kt
+++ b/data/database/src/commonMain/kotlin/com/tunjid/heron/data/database/daos/ListDao.kt
@@ -109,18 +109,6 @@ interface ListDao {
         """
         SELECT lm.* FROM listMembers lm
         JOIN lists l ON lm.listUri = l.uri
-        WHERE l.creatorId = :signedInUserId
-    """,
-    )
-    fun listMembersCreatedByProfile(
-        signedInUserId: String,
-    ): Flow<List<PopulatedListMemberEntity>>
-
-    @Transaction
-    @Query(
-        """
-        SELECT lm.* FROM listMembers lm
-        JOIN lists l ON lm.listUri = l.uri
         WHERE lm.subjectId = :profileId
         AND l.creatorId = :signedInUserId
     """,

--- a/feature/profile/src/commonMain/composeResources/values/strings.xml
+++ b/feature/profile/src/commonMain/composeResources/values/strings.xml
@@ -47,4 +47,5 @@
     <string name="publish_with_pckt">Publish with Pckt</string>
     <string name="publish_with_leaflet">Publish with Leaflet</string>
     <string name="no_lists">No Lists</string>
+    <string name="update_profile_in_lists">Update %1$s in Lists</string>
 </resources>

--- a/feature/profile/src/commonMain/composeResources/values/strings.xml
+++ b/feature/profile/src/commonMain/composeResources/values/strings.xml
@@ -46,4 +46,5 @@
     <string name="import_rss_blog">Import your RSS blog</string>
     <string name="publish_with_pckt">Publish with Pckt</string>
     <string name="publish_with_leaflet">Publish with Leaflet</string>
+    <string name="no_lists">No Lists</string>
 </resources>

--- a/feature/profile/src/commonMain/kotlin/com/tunjid/heron/profile/ProfileScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/tunjid/heron/profile/ProfileScreen.kt
@@ -327,7 +327,7 @@ internal fun ProfileScreen(
                 ) {
                     state.isSubscribedToLabeler
                 },
-                memberShips = state.profileListMemberships,
+                memberships = state.profileListMembershipsMap,
                 listsStateHolder = state.signedInProfileListsHolder,
                 viewerState = state.viewerState,
                 timelineStateHolders = remember(updatedStateHolders) {
@@ -407,6 +407,16 @@ internal fun ProfileScreen(
                             recordUri = listMemberUri,
                         ),
                     )
+                },
+                onUpdateCreatedListMembers = { signedInProfileId ->
+                    actions(
+                        Action.UpdateCreatedListMembers(
+                            signedInProfileId = signedInProfileId,
+                        ),
+                    )
+                },
+                onDismissListPicker = {
+                    actions(Action.DismissListPickerSheet)
                 },
             )
         },
@@ -636,7 +646,7 @@ private fun ProfileHeader(
     commonFollowerCount: Long?,
     commonFollowers: List<Profile>,
     subscribedLabelers: List<Labeler>,
-    memberShips: List<ListMember>,
+    memberships: Map<ListUri, ListMember>,
     preferences: Preferences,
     isRefreshing: Boolean,
     isSignedInProfile: Boolean,
@@ -657,6 +667,8 @@ private fun ProfileHeader(
     onUpdateProfileLiveStatus: () -> Unit,
     onAddListMember: (ProfileId, ListUri) -> Unit,
     onRemoveListMember: (ListMemberUri) -> Unit,
+    onUpdateCreatedListMembers: (ProfileId) -> Unit,
+    onDismissListPicker: () -> Unit,
 ) = with(paneScaffoldState) {
     Box(
         modifier = modifier
@@ -723,7 +735,7 @@ private fun ProfileHeader(
                     isSignedInProfile = isSignedInProfile,
                     isSubscribedToLabeler = isSubscribedToLabeler,
                     viewerState = viewerState,
-                    memberShips = memberShips,
+                    memberships = memberships,
                     signedInProfileId = signedInProfileId,
                     onViewerStateClicked = onViewerStateClicked,
                     onEditClick = onEditClick,
@@ -732,6 +744,8 @@ private fun ProfileHeader(
                     onUpdateProfileLiveStatus = onUpdateProfileLiveStatus,
                     onAddListMember = onAddListMember,
                     onRemoveListMember = onRemoveListMember,
+                    onUpdateCreatedListMembers = onUpdateCreatedListMembers,
+                    onDismissListPickerSheet = onDismissListPicker,
                 )
                 ProfileStats(
                     modifier = Modifier.fillMaxWidth(),
@@ -972,7 +986,7 @@ private fun ProfileHeadline(
     isSignedInProfile: Boolean,
     isSubscribedToLabeler: Boolean,
     viewerState: ProfileViewerState?,
-    memberShips: List<ListMember>,
+    memberships: Map<ListUri, ListMember>,
     onEditClick: () -> Unit,
     onViewerStateClicked: (ProfileViewerState?) -> Unit,
     onToggleLabelerSubscription: (ProfileId, Boolean) -> Unit,
@@ -980,16 +994,22 @@ private fun ProfileHeadline(
     onUpdateProfileLiveStatus: () -> Unit,
     onAddListMember: (ProfileId, ListUri) -> Unit,
     onRemoveListMember: (ListMemberUri) -> Unit,
+    onUpdateCreatedListMembers: (ProfileId) -> Unit,
+    onDismissListPickerSheet: () -> Unit,
 ) {
     val profileRestrictionsDialogState = rememberProfileRestrictionsDialogState(
         onApproved = onModerationAction,
     )
     val profileListPickerSheetState = rememberListMemberPickerSheetState(
         listsStateHolder = listsStateHolder,
-        memberships = memberShips,
+        memberships = memberships,
         profile = profile,
         onAddListMember = onAddListMember,
         onRemoveListMember = onRemoveListMember,
+        onShown = {
+            signedInProfileId?.let { onUpdateCreatedListMembers(it) }
+        },
+        onDismiss = onDismissListPickerSheet,
     )
     AttributionLayout(
         modifier = modifier,

--- a/feature/profile/src/commonMain/kotlin/com/tunjid/heron/profile/ProfileScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/tunjid/heron/profile/ProfileScreen.kt
@@ -95,6 +95,7 @@ import com.tunjid.heron.data.core.models.Conversation
 import com.tunjid.heron.data.core.models.FeedList
 import com.tunjid.heron.data.core.models.Labeler
 import com.tunjid.heron.data.core.models.LinkTarget
+import com.tunjid.heron.data.core.models.ListMember
 import com.tunjid.heron.data.core.models.MutedWordPreference
 import com.tunjid.heron.data.core.models.Post
 import com.tunjid.heron.data.core.models.Preferences
@@ -106,6 +107,8 @@ import com.tunjid.heron.data.core.models.id
 import com.tunjid.heron.data.core.models.link
 import com.tunjid.heron.data.core.models.path
 import com.tunjid.heron.data.core.models.stubProfile
+import com.tunjid.heron.data.core.types.ListMemberUri
+import com.tunjid.heron.data.core.types.ListUri
 import com.tunjid.heron.data.core.types.ProfileId
 import com.tunjid.heron.data.core.types.ProfileUri.Companion.asSelfLabelerUri
 import com.tunjid.heron.data.core.types.RecordUri
@@ -120,6 +123,7 @@ import com.tunjid.heron.media.video.LocalVideoPlayerController
 import com.tunjid.heron.profile.ProfileLiveStatusSheetState.Companion.rememberUpdatedProfileLiveStatusSheetState
 import com.tunjid.heron.profile.ui.LabelerSettings
 import com.tunjid.heron.profile.ui.LabelerState
+import com.tunjid.heron.profile.ui.ListMemberPickerSheetState.Companion.rememberListMemberPickerSheetState
 import com.tunjid.heron.profile.ui.ProfileActionsMenu
 import com.tunjid.heron.profile.ui.ProfileCollectionSharedElementPrefix
 import com.tunjid.heron.profile.ui.ProfileLabels
@@ -179,6 +183,7 @@ import com.tunjid.heron.timeline.utilities.sharedElementPrefix
 import com.tunjid.heron.timeline.utilities.timelineHorizontalPadding
 import com.tunjid.heron.ui.AttributionLayout
 import com.tunjid.heron.ui.OverlappingAvatarRow
+import com.tunjid.heron.ui.PaneTransitionScope
 import com.tunjid.heron.ui.Tab
 import com.tunjid.heron.ui.Tabs
 import com.tunjid.heron.ui.TabsState.Companion.rememberTabsState
@@ -203,6 +208,7 @@ import heron.feature.profile.generated.resources.labels
 import heron.feature.profile.generated.resources.posts
 import heron.ui.core.generated.resources.action_edit_live_status
 import heron.ui.core.generated.resources.action_go_live
+import heron.ui.core.generated.resources.add_to_list
 import heron.ui.core.generated.resources.followers
 import heron.ui.core.generated.resources.following
 import heron.ui.core.generated.resources.viewer_state_block_account
@@ -322,6 +328,8 @@ internal fun ProfileScreen(
                 ) {
                     state.isSubscribedToLabeler
                 },
+                memberShips = state.profileListMemberships,
+                listsStateHolder = state.signedInProfileListsHolder,
                 viewerState = state.viewerState,
                 timelineStateHolders = remember(updatedStateHolders) {
                     updatedStateHolders.filterIsInstance<ProfileScreenStateHolders.Timeline>()
@@ -386,6 +394,21 @@ internal fun ProfileScreen(
                 },
                 onModerationAction = actions,
                 onUpdateProfileLiveStatus = profileUpdateLiveStatusSheetState::show,
+                onAddListMember = { profileId, listUri ->
+                    actions(
+                        Action.AddListMember(
+                            subjectId = profileId,
+                            listUri = listUri,
+                        ),
+                    )
+                },
+                onRemoveListMember = { listMemberUri ->
+                    actions(
+                        Action.DeleteRecord(
+                            recordUri = listMemberUri,
+                        ),
+                    )
+                },
             )
         },
         body = {
@@ -614,6 +637,7 @@ private fun ProfileHeader(
     commonFollowerCount: Long?,
     commonFollowers: List<Profile>,
     subscribedLabelers: List<Labeler>,
+    memberShips: List<ListMember>,
     preferences: Preferences,
     isRefreshing: Boolean,
     isSignedInProfile: Boolean,
@@ -621,6 +645,7 @@ private fun ProfileHeader(
     signedInProfileId: ProfileId?,
     viewerState: ProfileViewerState?,
     timelineStateHolders: List<ProfileScreenStateHolders.Timeline>,
+    listsStateHolder: ProfileScreenStateHolders.Records.Lists?,
     avatarSharedElementKey: String,
     onRefreshTabClicked: (Int) -> Unit,
     onViewerStateClicked: (ProfileViewerState?) -> Unit,
@@ -631,6 +656,8 @@ private fun ProfileHeader(
     onToggleLabelerSubscription: (ProfileId, Boolean) -> Unit,
     onModerationAction: (Action.Moderation) -> Unit,
     onUpdateProfileLiveStatus: () -> Unit,
+    onAddListMember: (ProfileId, ListUri) -> Unit,
+    onRemoveListMember: (ListMemberUri) -> Unit,
 ) = with(paneScaffoldState) {
     Box(
         modifier = modifier
@@ -692,16 +719,21 @@ private fun ProfileHeader(
                 Spacer(Modifier.height(24.dp))
                 ProfileHeadline(
                     modifier = Modifier.fillMaxWidth(),
+                    paneTransitionScope = paneScaffoldState,
+                    listsStateHolder = listsStateHolder,
                     profile = profile,
                     isSignedInProfile = isSignedInProfile,
                     isSubscribedToLabeler = isSubscribedToLabeler,
                     viewerState = viewerState,
+                    memberShips = memberShips,
                     signedInProfileId = signedInProfileId,
                     onViewerStateClicked = onViewerStateClicked,
                     onEditClick = onEditClick,
                     onToggleLabelerSubscription = onToggleLabelerSubscription,
                     onModerationAction = onModerationAction,
                     onUpdateProfileLiveStatus = onUpdateProfileLiveStatus,
+                    onAddListMember = onAddListMember,
+                    onRemoveListMember = onRemoveListMember,
                 )
                 ProfileStats(
                     modifier = Modifier.fillMaxWidth(),
@@ -936,19 +968,32 @@ private fun ProfileAvatar(
 @Composable
 private fun ProfileHeadline(
     modifier: Modifier = Modifier,
+    paneTransitionScope: PaneTransitionScope,
+    listsStateHolder: ProfileScreenStateHolders.Records.Lists?,
     profile: Profile,
     signedInProfileId: ProfileId?,
     isSignedInProfile: Boolean,
     isSubscribedToLabeler: Boolean,
     viewerState: ProfileViewerState?,
+    memberShips: List<ListMember>,
     onEditClick: () -> Unit,
     onViewerStateClicked: (ProfileViewerState?) -> Unit,
     onToggleLabelerSubscription: (ProfileId, Boolean) -> Unit,
     onModerationAction: (Action.Moderation) -> Unit,
     onUpdateProfileLiveStatus: () -> Unit,
+    onAddListMember: (ProfileId, ListUri) -> Unit,
+    onRemoveListMember: (ListMemberUri) -> Unit,
 ) {
     val profileRestrictionsDialogState = rememberProfileRestrictionsDialogState(
         onApproved = onModerationAction,
+    )
+    val profileListPickerSheetState = rememberListMemberPickerSheetState(
+        paneTransitionScope = paneTransitionScope,
+        listsStateHolder = listsStateHolder,
+        memberships = memberShips,
+        profile = profile,
+        onAddListMember = onAddListMember,
+        onRemoveListMember = onRemoveListMember,
     )
     AttributionLayout(
         modifier = modifier,
@@ -1050,6 +1095,8 @@ private fun ProfileHeadline(
                                                         profileId = profile.did,
                                                     ),
                                                 )
+                                            CommonStrings.add_to_list ->
+                                                profileListPickerSheetState.show()
                                         }
                                     },
                                 )

--- a/feature/profile/src/commonMain/kotlin/com/tunjid/heron/profile/ProfileScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/tunjid/heron/profile/ProfileScreen.kt
@@ -183,7 +183,6 @@ import com.tunjid.heron.timeline.utilities.sharedElementPrefix
 import com.tunjid.heron.timeline.utilities.timelineHorizontalPadding
 import com.tunjid.heron.ui.AttributionLayout
 import com.tunjid.heron.ui.OverlappingAvatarRow
-import com.tunjid.heron.ui.PaneTransitionScope
 import com.tunjid.heron.ui.Tab
 import com.tunjid.heron.ui.Tabs
 import com.tunjid.heron.ui.TabsState.Companion.rememberTabsState
@@ -719,7 +718,6 @@ private fun ProfileHeader(
                 Spacer(Modifier.height(24.dp))
                 ProfileHeadline(
                     modifier = Modifier.fillMaxWidth(),
-                    paneTransitionScope = paneScaffoldState,
                     listsStateHolder = listsStateHolder,
                     profile = profile,
                     isSignedInProfile = isSignedInProfile,
@@ -968,7 +966,6 @@ private fun ProfileAvatar(
 @Composable
 private fun ProfileHeadline(
     modifier: Modifier = Modifier,
-    paneTransitionScope: PaneTransitionScope,
     listsStateHolder: ProfileScreenStateHolders.Records.Lists?,
     profile: Profile,
     signedInProfileId: ProfileId?,
@@ -988,7 +985,6 @@ private fun ProfileHeadline(
         onApproved = onModerationAction,
     )
     val profileListPickerSheetState = rememberListMemberPickerSheetState(
-        paneTransitionScope = paneTransitionScope,
         listsStateHolder = listsStateHolder,
         memberships = memberShips,
         profile = profile,

--- a/feature/profile/src/commonMain/kotlin/com/tunjid/heron/profile/ProfileViewModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/tunjid/heron/profile/ProfileViewModel.kt
@@ -90,7 +90,6 @@ import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.take
@@ -283,7 +282,7 @@ private fun loadProfileMutations(
     )
         .distinctUntilChanged()
         .flatMapLatest { (profile, signedInProfile) ->
-            profileRepository.membershipsByProfile(profile.did)
+            recordRepository.listMembersByProfile(profile.did)
                 .map { memberships ->
                     Triple(memberships, profile, signedInProfile)
                 }

--- a/feature/profile/src/commonMain/kotlin/com/tunjid/heron/profile/ProfileViewModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/tunjid/heron/profile/ProfileViewModel.kt
@@ -212,6 +212,10 @@ class ActualProfileViewModel(
                         is Action.AddListMember -> action.flow.addListMemberMutations(
                             writeQueue = writeQueue,
                         )
+                        is Action.UpdateCreatedListMembers -> action.flow.updateCreatedListMembersMutations(
+                            writeQueue = writeQueue,
+                        )
+                        is Action.DismissListPickerSheet -> action.flow.dismissListPickerSheet()
                     }
                 },
             )
@@ -284,10 +288,11 @@ private fun loadProfileMutations(
         .flatMapLatest { (profile, signedInProfile) ->
             recordRepository.listMembersByProfile(profile.did)
                 .map { memberships ->
-                    Triple(memberships, profile, signedInProfile)
+                    val membershipMap = memberships.associateBy { it.listUri }
+                    Triple(membershipMap, profile, signedInProfile)
                 }
         }
-        .mapToManyMutations { (memberships, profile, signedInProfile) ->
+        .mapToManyMutations { (membershipMap, profile, signedInProfile) ->
             val isSignedIn = signedInProfile != null
             val isSignedInProfile = signedInProfile?.let {
                 it.did.id == profileId.id || it.handle.id == profileId.id
@@ -298,7 +303,7 @@ private fun loadProfileMutations(
                     profile = profile,
                     signedInProfileId = signedInProfile?.did,
                     isSignedInProfile = isSignedInProfile,
-                    profileListMemberships = memberships,
+                    profileListMembershipsMap = membershipMap,
                 )
             }
 
@@ -556,6 +561,19 @@ private fun Flow<Action.AddListMember>.addListMemberMutations(
     if (memo != null) emit { copy(messages = messages + memo) }
 }
 
+private fun Flow<Action.UpdateCreatedListMembers>.updateCreatedListMembersMutations(
+    writeQueue: WriteQueue,
+): Flow<Mutation<State>> = this.enqueueMutations(
+    writeQueue,
+    toWritable = { action ->
+        Writable.FeedList.UpdateCreatedListMembers(
+            signedInProfileId = action.signedInProfileId,
+        )
+    },
+) { _, memo ->
+    if (memo != null) emit { copy(messages = messages + memo) }
+}
+
 private fun Flow<Action.ToggleViewerState>.toggleViewerStateMutations(
     writeQueue: WriteQueue,
 ): Flow<Mutation<State>> =
@@ -596,6 +614,11 @@ private fun Flow<Action.UpdatePreferences>.feedGeneratorStatusMutations(
 private fun Flow<Action.PageChanged>.pageChangeMutations(): Flow<Mutation<State>> =
     mapToMutation { action ->
         copy(currentPage = action.page)
+    }
+
+private fun Flow<Action.DismissListPickerSheet>.dismissListPickerSheet(): Flow<Mutation<State>> =
+    mapToMutation {
+        copy(signedInProfileListsHolder = null)
     }
 
 private fun CoroutineScope.recordStateHolders(

--- a/feature/profile/src/commonMain/kotlin/com/tunjid/heron/profile/ProfileViewModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/tunjid/heron/profile/ProfileViewModel.kt
@@ -283,12 +283,10 @@ private fun loadProfileMutations(
     )
         .distinctUntilChanged()
         .flatMapLatest { (profile, signedInProfile) ->
-            combine(
-                profileRepository.membershipsByProfile(profile.did),
-                flowOf(profile),
-                flowOf<Profile?>(signedInProfile),
-                ::Triple,
-            )
+            profileRepository.membershipsByProfile(profile.did)
+                .map { memberships ->
+                    Triple(memberships, profile, signedInProfile)
+                }
         }
         .mapToManyMutations { (memberships, profile, signedInProfile) ->
             val isSignedIn = signedInProfile != null
@@ -308,11 +306,7 @@ private fun loadProfileMutations(
             val state = currentState()
             val hasProfileStateHolders = state.stateHolders.isNotEmpty()
 
-            // TODO: This logic assumes that the tabs for the profile are static.
-            // Revisit this.
-            if (hasProfileStateHolders) return@mapToManyMutations
-
-            if (signedInProfile != null && state.signedInProfileListsHolder == null) {
+            if (signedInProfile != null && (state.signedInProfileListsHolder == null || state.signedInProfileId != signedInProfile.did)) {
                 emit {
                     copy(
                         signedInProfileListsHolder = scope.signedInProfileListsHolder(
@@ -322,6 +316,10 @@ private fun loadProfileMutations(
                     )
                 }
             }
+
+            // TODO: This logic assumes that the tabs for the profile are static.
+            // Revisit this.
+            if (hasProfileStateHolders) return@mapToManyMutations
 
             emitAll(
                 Timeline.Profile.Type.entries

--- a/feature/profile/src/commonMain/kotlin/com/tunjid/heron/profile/ProfileViewModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/tunjid/heron/profile/ProfileViewModel.kt
@@ -25,6 +25,7 @@ import com.tunjid.heron.data.core.models.FeedGenerator
 import com.tunjid.heron.data.core.models.FeedList
 import com.tunjid.heron.data.core.models.Labeler
 import com.tunjid.heron.data.core.models.LinkTarget
+import com.tunjid.heron.data.core.models.ListMember
 import com.tunjid.heron.data.core.models.Profile
 import com.tunjid.heron.data.core.models.Record
 import com.tunjid.heron.data.core.models.StandardDocument
@@ -89,6 +90,7 @@ import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.take
@@ -208,6 +210,9 @@ class ActualProfileViewModel(
                         is Action.UpdateLiveStatus -> action.flow.liveStatusMutations(
                             writeQueue = writeQueue,
                         )
+                        is Action.AddListMember -> action.flow.addListMemberMutations(
+                            writeQueue = writeQueue,
+                        )
                     }
                 },
             )
@@ -277,7 +282,15 @@ private fun loadProfileMutations(
         ::Pair,
     )
         .distinctUntilChanged()
-        .mapToManyMutations { (profile, signedInProfile) ->
+        .flatMapLatest { (profile, signedInProfile) ->
+            combine(
+                profileRepository.membershipsByProfile(profile.did),
+                flowOf(profile),
+                flowOf<Profile?>(signedInProfile),
+                ::Triple,
+            )
+        }
+        .mapToManyMutations { (memberships, profile, signedInProfile) ->
             val isSignedIn = signedInProfile != null
             val isSignedInProfile = signedInProfile?.let {
                 it.did.id == profileId.id || it.handle.id == profileId.id
@@ -288,6 +301,7 @@ private fun loadProfileMutations(
                     profile = profile,
                     signedInProfileId = signedInProfile?.did,
                     isSignedInProfile = isSignedInProfile,
+                    profileListMemberships = memberships,
                 )
             }
 
@@ -297,6 +311,17 @@ private fun loadProfileMutations(
             // TODO: This logic assumes that the tabs for the profile are static.
             // Revisit this.
             if (hasProfileStateHolders) return@mapToManyMutations
+
+            if (signedInProfile != null && state.signedInProfileListsHolder == null) {
+                emit {
+                    copy(
+                        signedInProfileListsHolder = scope.signedInProfileListsHolder(
+                            signedInProfileId = signedInProfile.did,
+                            recordRepository = recordRepository,
+                        ),
+                    )
+                }
+            }
 
             emitAll(
                 Timeline.Profile.Type.entries
@@ -518,6 +543,22 @@ private fun Flow<Action.DeleteRecord>.deleteRecordMutations(
     if (memo != null) emit { copy(messages = messages + memo) }
 }
 
+private fun Flow<Action.AddListMember>.addListMemberMutations(
+    writeQueue: WriteQueue,
+): Flow<Mutation<State>> = this.enqueueMutations(
+    writeQueue,
+    toWritable = {
+        Writable.FeedList.AddMember(
+            create = ListMember.Create(
+                subjectId = it.subjectId,
+                listUri = it.listUri,
+            ),
+        )
+    },
+) { _, memo ->
+    if (memo != null) emit { copy(messages = messages + memo) }
+}
+
 private fun Flow<Action.ToggleViewerState>.toggleViewerStateMutations(
     writeQueue: WriteQueue,
 ): Flow<Mutation<State>> =
@@ -624,6 +665,26 @@ private fun CoroutineScope.recordStateHolders(
                 itemId = FeedList::cid,
                 cursorListLoader = recordRepository::lists,
             ),
+        ),
+    )
+
+private fun CoroutineScope.signedInProfileListsHolder(
+    signedInProfileId: Id.Profile,
+    recordRepository: RecordRepository,
+): ProfileScreenStateHolders.Records.Lists =
+    ProfileScreenStateHolders.Records.Lists(
+        mutator = recordStateHolder(
+            initialState = RecordState(
+                stringResource = Res.string.lists,
+                tilingData = TilingState.Data(
+                    currentQuery = ProfilesQuery(
+                        profileId = signedInProfileId,
+                        data = defaultQueryData(),
+                    ),
+                ),
+            ),
+            itemId = FeedList::cid,
+            cursorListLoader = recordRepository::lists,
         ),
     )
 

--- a/feature/profile/src/commonMain/kotlin/com/tunjid/heron/profile/State.kt
+++ b/feature/profile/src/commonMain/kotlin/com/tunjid/heron/profile/State.kt
@@ -93,9 +93,9 @@ data class State(
     @Transient
     val stateHolders: List<ProfileScreenStateHolders> = emptyList(),
     @Transient
-    val signedInProfileListsHolder: Records.Lists? = null,
+    val profileListMembershipsMap: Map<ListUri, ListMember> = emptyMap(),
     @Transient
-    val profileListMemberships: List<ListMember> = emptyList(),
+    val signedInProfileListsHolder: Records.Lists? = null,
     @Transient
     val messages: List<Memo> = emptyList(),
 )
@@ -281,6 +281,12 @@ sealed class Action(val key: String) {
         val subjectId: ProfileId,
         val listUri: ListUri,
     ) : Action(key = "AddListMember")
+
+    data class UpdateCreatedListMembers(
+        val signedInProfileId: ProfileId,
+    ) : Action(key = "UpdateCreatedListMember")
+
+    data object DismissListPickerSheet : Action(key = "DismissListPickerSheet")
 
     data class SendPostInteraction(
         val interaction: Post.Interaction,

--- a/feature/profile/src/commonMain/kotlin/com/tunjid/heron/profile/State.kt
+++ b/feature/profile/src/commonMain/kotlin/com/tunjid/heron/profile/State.kt
@@ -22,6 +22,7 @@ import com.tunjid.heron.data.core.models.FeedList
 import com.tunjid.heron.data.core.models.Label
 import com.tunjid.heron.data.core.models.Labelers
 import com.tunjid.heron.data.core.models.LinkTarget
+import com.tunjid.heron.data.core.models.ListMember
 import com.tunjid.heron.data.core.models.MutedWordPreference
 import com.tunjid.heron.data.core.models.Post
 import com.tunjid.heron.data.core.models.Preferences
@@ -36,6 +37,7 @@ import com.tunjid.heron.data.core.models.stubProfile
 import com.tunjid.heron.data.core.models.toUrlEncodedBase64
 import com.tunjid.heron.data.core.types.BlockUri
 import com.tunjid.heron.data.core.types.FollowUri
+import com.tunjid.heron.data.core.types.ListUri
 import com.tunjid.heron.data.core.types.ProfileHandle
 import com.tunjid.heron.data.core.types.ProfileId
 import com.tunjid.heron.data.core.types.RecordUri
@@ -90,6 +92,10 @@ data class State(
     val sourceIdsToHasUpdates: Map<String, Boolean> = emptyMap(),
     @Transient
     val stateHolders: List<ProfileScreenStateHolders> = emptyList(),
+    @Transient
+    val signedInProfileListsHolder: Records.Lists? = null,
+    @Transient
+    val profileListMemberships: List<ListMember> = emptyList(),
     @Transient
     val messages: List<Memo> = emptyList(),
 )
@@ -270,6 +276,11 @@ sealed class Action(val key: String) {
     data class DeleteRecord(
         val recordUri: RecordUri,
     ) : Action(key = "DeleteRecord")
+
+    data class AddListMember(
+        val subjectId: ProfileId,
+        val listUri: ListUri,
+    ) : Action(key = "AddListMember")
 
     data class SendPostInteraction(
         val interaction: Post.Interaction,

--- a/feature/profile/src/commonMain/kotlin/com/tunjid/heron/profile/ui/ListMemberPickerSheetState.kt
+++ b/feature/profile/src/commonMain/kotlin/com/tunjid/heron/profile/ui/ListMemberPickerSheetState.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.PlaylistAdd
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -31,6 +30,7 @@ import com.tunjid.heron.ui.sheets.BottomSheetScope.Companion.rememberBottomSheet
 import com.tunjid.heron.ui.sheets.BottomSheetState
 import heron.feature.profile.generated.resources.Res
 import heron.feature.profile.generated.resources.no_lists
+import heron.feature.profile.generated.resources.update_profile_in_lists
 import org.jetbrains.compose.resources.stringResource
 
 class ListMemberPickerSheetState(
@@ -84,7 +84,10 @@ fun ListMemberPickerBottomSheet(
 
     state.ModalBottomSheet {
         Text(
-            text = "Update ${profile.displayName ?: profile.handle.id} in Lists",
+            text = stringResource(
+                Res.string.update_profile_in_lists,
+                profile.displayName ?: profile.handle.id,
+            ),
             style = MaterialTheme.typography.titleMedium,
             modifier = Modifier
                 .padding(horizontal = 16.dp, vertical = 12.dp),

--- a/feature/profile/src/commonMain/kotlin/com/tunjid/heron/profile/ui/ListMemberPickerSheetState.kt
+++ b/feature/profile/src/commonMain/kotlin/com/tunjid/heron/profile/ui/ListMemberPickerSheetState.kt
@@ -12,7 +12,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -34,23 +34,31 @@ import org.jetbrains.compose.resources.stringResource
 
 class ListMemberPickerSheetState(
     scope: BottomSheetScope,
+    private val onDismiss: () -> Unit,
 ) : BottomSheetState(scope) {
 
-    override fun onHidden() {}
+    override fun onHidden() {
+        onDismiss()
+    }
 
     companion object {
         @Composable
         fun rememberListMemberPickerSheetState(
             listsStateHolder: ProfileScreenStateHolders.Records.Lists?,
-            memberships: List<ListMember>,
+            memberships: Map<ListUri, ListMember>,
             profile: Profile,
             onAddListMember: (ProfileId, ListUri) -> Unit,
             onRemoveListMember: (ListMemberUri) -> Unit,
+            onShown: () -> Unit,
+            onDismiss: () -> Unit,
         ): ListMemberPickerSheetState {
             val state = rememberBottomSheetState(
                 skipPartiallyExpanded = false,
             ) { scope ->
-                ListMemberPickerSheetState(scope = scope)
+                ListMemberPickerSheetState(
+                    scope = scope,
+                    onDismiss = onDismiss,
+                )
             }
             ListMemberPickerBottomSheet(
                 state = state,
@@ -59,6 +67,7 @@ class ListMemberPickerSheetState(
                 profile = profile,
                 onAddListMember = onAddListMember,
                 onRemoveListMember = onRemoveListMember,
+                onShown = onShown,
             )
             return state
         }
@@ -70,15 +79,16 @@ fun ListMemberPickerBottomSheet(
     state: ListMemberPickerSheetState,
     profile: Profile,
     listsStateHolder: ProfileScreenStateHolders.Records.Lists?,
-    memberships: List<ListMember>,
+    memberships: Map<ListUri, ListMember>,
     onAddListMember: (ProfileId, ListUri) -> Unit,
     onRemoveListMember: (ListMemberUri) -> Unit,
+    onShown: () -> Unit,
 ) {
-    val membershipByListUri = remember(memberships) {
-        memberships.associateBy { it.listUri }
-    }
-
     state.ModalBottomSheet {
+        LaunchedEffect(Unit) {
+            onShown()
+        }
+
         Text(
             text = stringResource(
                 Res.string.update_profile_in_lists,
@@ -118,7 +128,7 @@ fun ListMemberPickerBottomSheet(
                 itemContent = { feedList ->
                     ListMemberPickerItem(
                         list = feedList,
-                        membership = membershipByListUri[feedList.uri],
+                        membership = memberships[feedList.uri],
                         profileId = profile.did,
                         onAddListMember = onAddListMember,
                         onRemoveListMember = onRemoveListMember,

--- a/feature/profile/src/commonMain/kotlin/com/tunjid/heron/profile/ui/ListMemberPickerSheetState.kt
+++ b/feature/profile/src/commonMain/kotlin/com/tunjid/heron/profile/ui/ListMemberPickerSheetState.kt
@@ -1,0 +1,133 @@
+package com.tunjid.heron.profile.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.PlaylistAdd
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.tunjid.heron.data.core.models.ListMember
+import com.tunjid.heron.data.core.models.Profile
+import com.tunjid.heron.data.core.types.ListMemberUri
+import com.tunjid.heron.data.core.types.ListUri
+import com.tunjid.heron.data.core.types.ProfileId
+import com.tunjid.heron.profile.ProfileScreenStateHolders
+import com.tunjid.heron.timeline.ui.list.ListMemberPickerItem
+import com.tunjid.heron.ui.PaneTransitionScope
+import com.tunjid.heron.ui.sheets.BottomSheetScope
+import com.tunjid.heron.ui.sheets.BottomSheetScope.Companion.ModalBottomSheet
+import com.tunjid.heron.ui.sheets.BottomSheetScope.Companion.rememberBottomSheetState
+import com.tunjid.heron.ui.sheets.BottomSheetState
+import heron.feature.profile.generated.resources.Res
+import heron.feature.profile.generated.resources.no_lists
+import org.jetbrains.compose.resources.stringResource
+
+class ListMemberPickerSheetState(
+    scope: BottomSheetScope,
+) : BottomSheetState(scope) {
+
+    override fun onHidden() {}
+
+    companion object {
+        @Composable
+        fun rememberListMemberPickerSheetState(
+            paneTransitionScope: PaneTransitionScope,
+            listsStateHolder: ProfileScreenStateHolders.Records.Lists?,
+            memberships: List<ListMember>,
+            profile: Profile,
+            onAddListMember: (ProfileId, ListUri) -> Unit,
+            onRemoveListMember: (ListMemberUri) -> Unit,
+        ): ListMemberPickerSheetState {
+            val state = rememberBottomSheetState(
+                skipPartiallyExpanded = false,
+            ) { scope ->
+                ListMemberPickerSheetState(scope = scope)
+            }
+            ListMemberPickerBottomSheet(
+                paneTransitionScope = paneTransitionScope,
+                state = state,
+                listsStateHolder = listsStateHolder,
+                memberships = memberships,
+                profile = profile,
+                onAddListMember = onAddListMember,
+                onRemoveListMember = onRemoveListMember,
+            )
+            return state
+        }
+    }
+}
+
+@Composable
+fun ListMemberPickerBottomSheet(
+    paneTransitionScope: PaneTransitionScope,
+    state: ListMemberPickerSheetState,
+    profile: Profile,
+    listsStateHolder: ProfileScreenStateHolders.Records.Lists?,
+    memberships: List<ListMember>,
+    onAddListMember: (ProfileId, ListUri) -> Unit,
+    onRemoveListMember: (ListMemberUri) -> Unit,
+) {
+    val membershipByListUri = remember(memberships) {
+        memberships.associateBy { it.listUri }
+    }
+
+    state.ModalBottomSheet {
+        Text(
+            text = "Update ${profile.displayName ?: profile.handle.id} in Lists",
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+        )
+
+        HorizontalDivider()
+
+        when (listsStateHolder) {
+            null -> Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Rounded.PlaylistAdd,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.outline,
+                    modifier = Modifier.size(48.dp),
+                )
+                Text(
+                    text = stringResource(Res.string.no_lists),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.outline,
+                )
+            }
+            else -> RecordList(
+                collectionStateHolder = listsStateHolder,
+                prefersCompactBottomNav = false,
+                itemKey = { it.cid.id },
+                itemContent = { feedList ->
+                    ListMemberPickerItem(
+                        paneTransitionScope = paneTransitionScope,
+                        list = feedList,
+                        membership = membershipByListUri[feedList.uri],
+                        profileId = profile.did,
+                        sharedElementPrefix = "list-member-picker",
+                        onAddListMember = onAddListMember,
+                        onRemoveListMember = onRemoveListMember,
+                    )
+                },
+            )
+        }
+    }
+}

--- a/feature/profile/src/commonMain/kotlin/com/tunjid/heron/profile/ui/ListMemberPickerSheetState.kt
+++ b/feature/profile/src/commonMain/kotlin/com/tunjid/heron/profile/ui/ListMemberPickerSheetState.kt
@@ -23,7 +23,6 @@ import com.tunjid.heron.data.core.types.ListUri
 import com.tunjid.heron.data.core.types.ProfileId
 import com.tunjid.heron.profile.ProfileScreenStateHolders
 import com.tunjid.heron.timeline.ui.list.ListMemberPickerItem
-import com.tunjid.heron.ui.PaneTransitionScope
 import com.tunjid.heron.ui.sheets.BottomSheetScope
 import com.tunjid.heron.ui.sheets.BottomSheetScope.Companion.ModalBottomSheet
 import com.tunjid.heron.ui.sheets.BottomSheetScope.Companion.rememberBottomSheetState
@@ -42,7 +41,6 @@ class ListMemberPickerSheetState(
     companion object {
         @Composable
         fun rememberListMemberPickerSheetState(
-            paneTransitionScope: PaneTransitionScope,
             listsStateHolder: ProfileScreenStateHolders.Records.Lists?,
             memberships: List<ListMember>,
             profile: Profile,
@@ -55,7 +53,6 @@ class ListMemberPickerSheetState(
                 ListMemberPickerSheetState(scope = scope)
             }
             ListMemberPickerBottomSheet(
-                paneTransitionScope = paneTransitionScope,
                 state = state,
                 listsStateHolder = listsStateHolder,
                 memberships = memberships,
@@ -70,7 +67,6 @@ class ListMemberPickerSheetState(
 
 @Composable
 fun ListMemberPickerBottomSheet(
-    paneTransitionScope: PaneTransitionScope,
     state: ListMemberPickerSheetState,
     profile: Profile,
     listsStateHolder: ProfileScreenStateHolders.Records.Lists?,
@@ -121,11 +117,9 @@ fun ListMemberPickerBottomSheet(
                 itemKey = { it.cid.id },
                 itemContent = { feedList ->
                     ListMemberPickerItem(
-                        paneTransitionScope = paneTransitionScope,
                         list = feedList,
                         membership = membershipByListUri[feedList.uri],
                         profileId = profile.did,
-                        sharedElementPrefix = "list-member-picker",
                         onAddListMember = onAddListMember,
                         onRemoveListMember = onRemoveListMember,
                     )

--- a/feature/profile/src/commonMain/kotlin/com/tunjid/heron/profile/ui/ProfileActionsMenu.kt
+++ b/feature/profile/src/commonMain/kotlin/com/tunjid/heron/profile/ui/ProfileActionsMenu.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.PlaylistAdd
 import androidx.compose.material.icons.automirrored.rounded.VolumeOff
 import androidx.compose.material.icons.automirrored.rounded.VolumeUp
 import androidx.compose.material.icons.filled.MoreVert
@@ -38,6 +39,7 @@ import com.tunjid.heron.data.core.models.isMuted
 import com.tunjid.heron.ui.text.CommonStrings
 import heron.ui.core.generated.resources.action_edit_live_status
 import heron.ui.core.generated.resources.action_go_live
+import heron.ui.core.generated.resources.add_to_list
 import heron.ui.core.generated.resources.more_options
 import heron.ui.core.generated.resources.viewer_state_block_account
 import heron.ui.core.generated.resources.viewer_state_mute_account
@@ -181,4 +183,12 @@ internal fun ProfileViewerState?.profileActionMenuItems(
             )
         }
     }
+
+    add(ProfileActionMenu.Divider)
+    add(
+        ProfileActionMenu.Item(
+            title = CommonStrings.add_to_list,
+            icon = Icons.AutoMirrored.Rounded.PlaylistAdd,
+        ),
+    )
 }

--- a/ui/core/src/commonMain/composeResources/values/strings.xml
+++ b/ui/core/src/commonMain/composeResources/values/strings.xml
@@ -179,4 +179,8 @@
     <string name="twitch_live_platform">Twitch</string>
     <string name="streamplace_live_platform">Streamplace</string>
     <string name="bluecast_live_platform">Bluecast</string>
+
+    <string name="add_to_list">Add to List</string>
+    <string name="action_add">Add</string>
+    <string name="action_remove">Remove</string>
 </resources>

--- a/ui/timeline/src/commonMain/composeResources/values/strings.xml
+++ b/ui/timeline/src/commonMain/composeResources/values/strings.xml
@@ -138,6 +138,7 @@
     <string name="writable_repost">repost</string>
     <string name="writable_repost_removal">repost removal</string>
     <string name="writable_add_list_member">list member addition</string>
+    <string name="writable_update_created_list_members">created list member update</string>
     <string name="writable_subscribe_standard_publication">publication subscription</string>
     <string name="writable_thread_gate_update">post reply update</string>
     <string name="writable_profile_status_update">profile status update</string>

--- a/ui/timeline/src/commonMain/composeResources/values/strings.xml
+++ b/ui/timeline/src/commonMain/composeResources/values/strings.xml
@@ -48,6 +48,7 @@
     <string name="starter_pack_by">Starter Pack by %1$s</string>
     <string name="labeling_service_by">Labeling Service by %1$s</string>
     <string name="list_by">List by %1$s</string>
+    <string name="list_by_you">List by you</string>
     <string name="show_more">Show More</string>
     <string name="sign_in">Sign In</string>
     <string name="pin_feed">Pin</string>

--- a/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/ui/list/FeedList.kt
+++ b/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/ui/list/FeedList.kt
@@ -17,26 +17,16 @@
 package com.tunjid.heron.timeline.ui.list
 
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.rounded.PlaylistAdd
-import androidx.compose.material.icons.rounded.PlaylistRemove
-import androidx.compose.material3.FilterChip
-import androidx.compose.material3.Icon
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import com.tunjid.heron.data.core.models.FeedList
-import com.tunjid.heron.data.core.models.ListMember
 import com.tunjid.heron.data.core.models.StarterPack
 import com.tunjid.heron.data.core.models.Timeline
 import com.tunjid.heron.data.core.models.Timeline.Update
-import com.tunjid.heron.data.core.types.ListMemberUri
 import com.tunjid.heron.data.core.types.ListUri
-import com.tunjid.heron.data.core.types.ProfileId
 import com.tunjid.heron.images.AsyncImage
 import com.tunjid.heron.images.ImageArgs
 import com.tunjid.heron.timeline.utilities.BlueskyClouds
@@ -46,12 +36,8 @@ import com.tunjid.heron.timeline.utilities.TimelineStatusSelection
 import com.tunjid.heron.timeline.utilities.avatarSharedElementKey
 import com.tunjid.heron.ui.PaneTransitionScope
 import com.tunjid.heron.ui.RecordLayout
-import com.tunjid.heron.ui.text.CommonStrings
-import heron.ui.core.generated.resources.action_add
-import heron.ui.core.generated.resources.action_remove
 import heron.ui.timeline.generated.resources.Res
 import heron.ui.timeline.generated.resources.list_by
-import heron.ui.timeline.generated.resources.list_by_you
 import heron.ui.timeline.generated.resources.starter_pack_by
 import org.jetbrains.compose.resources.stringResource
 
@@ -107,55 +93,6 @@ fun FeedList(
                     onListStatusUpdated = onListStatusUpdated,
                 )
             }
-        },
-    )
-}
-
-@Composable
-fun ListMemberPickerItem(
-    modifier: Modifier = Modifier,
-    paneTransitionScope: PaneTransitionScope,
-    list: FeedList,
-    membership: ListMember?,
-    profileId: ProfileId,
-    sharedElementPrefix: String,
-    onAddListMember: (ProfileId, ListUri) -> Unit,
-    onRemoveListMember: (ListMemberUri) -> Unit,
-) {
-    RecordLayout(
-        modifier = modifier,
-        paneTransitionScope = paneTransitionScope,
-        title = list.name,
-        subtitle = stringResource(Res.string.list_by_you),
-        description = list.description,
-        blurb = null,
-        sharedElementPrefix = sharedElementPrefix,
-        sharedElementType = list.uri,
-        avatar = {
-            val avatar = list.avatar ?: BlueskyClouds
-            AsyncImage(
-                modifier = Modifier.size(44.dp),
-                args = remember(avatar) {
-                    ImageArgs(
-                        url = avatar.uri,
-                        contentScale = ContentScale.Crop,
-                        contentDescription = null,
-                        shape = ListCollectionShape,
-                    )
-                },
-            )
-        },
-        action = {
-            ListMembershipChip(
-                isMember = membership != null,
-                onClick = {
-                    if (membership != null) {
-                        onRemoveListMember(membership.uri)
-                    } else {
-                        onAddListMember(profileId, list.uri)
-                    }
-                },
-            )
         },
     )
 }
@@ -223,30 +160,3 @@ fun FeedListStatus(
         },
     )
 }
-
-@Composable
-private fun ListMembershipChip(
-    isMember: Boolean,
-    onClick: () -> Unit,
-) {
-    val label = if (isMember) stringResource(CommonStrings.action_remove)
-    else stringResource(CommonStrings.action_add)
-
-    FilterChip(
-        selected = isMember,
-        onClick = onClick,
-        shape = ListMemberChipShape,
-        leadingIcon = {
-            Icon(
-                imageVector = if (isMember) Icons.Rounded.PlaylistRemove
-                else Icons.AutoMirrored.Rounded.PlaylistAdd,
-                contentDescription = label,
-            )
-        },
-        label = {
-            Text(label)
-        },
-    )
-}
-
-private val ListMemberChipShape = RoundedCornerShape(16.dp)

--- a/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/ui/list/FeedList.kt
+++ b/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/ui/list/FeedList.kt
@@ -51,6 +51,7 @@ import heron.ui.core.generated.resources.action_add
 import heron.ui.core.generated.resources.action_remove
 import heron.ui.timeline.generated.resources.Res
 import heron.ui.timeline.generated.resources.list_by
+import heron.ui.timeline.generated.resources.list_by_you
 import heron.ui.timeline.generated.resources.starter_pack_by
 import org.jetbrains.compose.resources.stringResource
 
@@ -125,10 +126,7 @@ fun ListMemberPickerItem(
         modifier = modifier,
         paneTransitionScope = paneTransitionScope,
         title = list.name,
-        subtitle = stringResource(
-            Res.string.list_by,
-            list.creator.handle.id,
-        ),
+        subtitle = stringResource(Res.string.list_by_you),
         description = list.description,
         blurb = null,
         sharedElementPrefix = sharedElementPrefix,

--- a/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/ui/list/FeedList.kt
+++ b/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/ui/list/FeedList.kt
@@ -17,16 +17,26 @@
 package com.tunjid.heron.timeline.ui.list
 
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.PlaylistAdd
+import androidx.compose.material.icons.rounded.PlaylistRemove
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import com.tunjid.heron.data.core.models.FeedList
+import com.tunjid.heron.data.core.models.ListMember
 import com.tunjid.heron.data.core.models.StarterPack
 import com.tunjid.heron.data.core.models.Timeline
 import com.tunjid.heron.data.core.models.Timeline.Update
+import com.tunjid.heron.data.core.types.ListMemberUri
 import com.tunjid.heron.data.core.types.ListUri
+import com.tunjid.heron.data.core.types.ProfileId
 import com.tunjid.heron.images.AsyncImage
 import com.tunjid.heron.images.ImageArgs
 import com.tunjid.heron.timeline.utilities.BlueskyClouds
@@ -36,6 +46,9 @@ import com.tunjid.heron.timeline.utilities.TimelineStatusSelection
 import com.tunjid.heron.timeline.utilities.avatarSharedElementKey
 import com.tunjid.heron.ui.PaneTransitionScope
 import com.tunjid.heron.ui.RecordLayout
+import com.tunjid.heron.ui.text.CommonStrings
+import heron.ui.core.generated.resources.action_add
+import heron.ui.core.generated.resources.action_remove
 import heron.ui.timeline.generated.resources.Res
 import heron.ui.timeline.generated.resources.list_by
 import heron.ui.timeline.generated.resources.starter_pack_by
@@ -93,6 +106,58 @@ fun FeedList(
                     onListStatusUpdated = onListStatusUpdated,
                 )
             }
+        },
+    )
+}
+
+@Composable
+fun ListMemberPickerItem(
+    modifier: Modifier = Modifier,
+    paneTransitionScope: PaneTransitionScope,
+    list: FeedList,
+    membership: ListMember?,
+    profileId: ProfileId,
+    sharedElementPrefix: String,
+    onAddListMember: (ProfileId, ListUri) -> Unit,
+    onRemoveListMember: (ListMemberUri) -> Unit,
+) {
+    RecordLayout(
+        modifier = modifier,
+        paneTransitionScope = paneTransitionScope,
+        title = list.name,
+        subtitle = stringResource(
+            Res.string.list_by,
+            list.creator.handle.id,
+        ),
+        description = list.description,
+        blurb = null,
+        sharedElementPrefix = sharedElementPrefix,
+        sharedElementType = list.uri,
+        avatar = {
+            val avatar = list.avatar ?: BlueskyClouds
+            AsyncImage(
+                modifier = Modifier.size(44.dp),
+                args = remember(avatar) {
+                    ImageArgs(
+                        url = avatar.uri,
+                        contentScale = ContentScale.Crop,
+                        contentDescription = null,
+                        shape = ListCollectionShape,
+                    )
+                },
+            )
+        },
+        action = {
+            ListMembershipChip(
+                isMember = membership != null,
+                onClick = {
+                    if (membership != null) {
+                        onRemoveListMember(membership.uri)
+                    } else {
+                        onAddListMember(profileId, list.uri)
+                    }
+                },
+            )
         },
     )
 }
@@ -160,3 +225,30 @@ fun FeedListStatus(
         },
     )
 }
+
+@Composable
+private fun ListMembershipChip(
+    isMember: Boolean,
+    onClick: () -> Unit,
+) {
+    val label = if (isMember) stringResource(CommonStrings.action_remove)
+    else stringResource(CommonStrings.action_add)
+
+    FilterChip(
+        selected = isMember,
+        onClick = onClick,
+        shape = ListMemberChipShape,
+        leadingIcon = {
+            Icon(
+                imageVector = if (isMember) Icons.Rounded.PlaylistRemove
+                else Icons.AutoMirrored.Rounded.PlaylistAdd,
+                contentDescription = label,
+            )
+        },
+        label = {
+            Text(label)
+        },
+    )
+}
+
+private val ListMemberChipShape = RoundedCornerShape(16.dp)

--- a/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/ui/list/ListMemberPicker.kt
+++ b/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/ui/list/ListMemberPicker.kt
@@ -1,0 +1,142 @@
+package com.tunjid.heron.timeline.ui.list
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.PlaylistAdd
+import androidx.compose.material.icons.rounded.PlaylistRemove
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
+import com.tunjid.heron.data.core.models.FeedList
+import com.tunjid.heron.data.core.models.ListMember
+import com.tunjid.heron.data.core.types.ListMemberUri
+import com.tunjid.heron.data.core.types.ListUri
+import com.tunjid.heron.data.core.types.ProfileId
+import com.tunjid.heron.images.AsyncImage
+import com.tunjid.heron.images.ImageArgs
+import com.tunjid.heron.timeline.utilities.BlueskyClouds
+import com.tunjid.heron.timeline.utilities.ListCollectionShape
+import com.tunjid.heron.ui.AttributionLayout
+import com.tunjid.heron.ui.RecordBlurb
+import com.tunjid.heron.ui.RecordSubtitle
+import com.tunjid.heron.ui.RecordText
+import com.tunjid.heron.ui.RecordTitle
+import com.tunjid.heron.ui.text.CommonStrings
+import heron.ui.core.generated.resources.action_add
+import heron.ui.core.generated.resources.action_remove
+import heron.ui.timeline.generated.resources.Res
+import heron.ui.timeline.generated.resources.list_by_you
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+fun ListMemberPickerItem(
+    modifier: Modifier = Modifier,
+    list: FeedList,
+    membership: ListMember?,
+    profileId: ProfileId,
+    onAddListMember: (ProfileId, ListUri) -> Unit,
+    onRemoveListMember: (ListMemberUri) -> Unit,
+) {
+    ListPickerRecordLayout(
+        modifier = modifier,
+        title = list.name,
+        subtitle = stringResource(Res.string.list_by_you),
+        description = list.description,
+        blurb = null,
+        avatar = {
+            val avatar = list.avatar ?: BlueskyClouds
+            AsyncImage(
+                modifier = Modifier.size(44.dp),
+                args = remember(avatar) {
+                    ImageArgs(
+                        url = avatar.uri,
+                        contentScale = ContentScale.Crop,
+                        contentDescription = null,
+                        shape = ListCollectionShape,
+                    )
+                },
+            )
+        },
+        action = {
+            ListMembershipChip(
+                isMember = membership != null,
+                onClick = {
+                    if (membership != null) onRemoveListMember(membership.uri)
+                    else onAddListMember(profileId, list.uri)
+                },
+            )
+        },
+    )
+}
+
+@Composable
+private fun ListMembershipChip(
+    isMember: Boolean,
+    onClick: () -> Unit,
+) {
+    val label = if (isMember) stringResource(CommonStrings.action_remove)
+    else stringResource(CommonStrings.action_add)
+
+    FilterChip(
+        selected = isMember,
+        onClick = onClick,
+        shape = ListMemberChipShape,
+        leadingIcon = {
+            Icon(
+                imageVector = if (isMember) Icons.Rounded.PlaylistRemove
+                else Icons.AutoMirrored.Rounded.PlaylistAdd,
+                contentDescription = label,
+            )
+        },
+        label = {
+            Text(label)
+        },
+    )
+}
+
+@Composable
+private fun ListPickerRecordLayout(
+    modifier: Modifier = Modifier,
+    title: String,
+    subtitle: String,
+    description: String?,
+    blurb: String?,
+    avatar: @Composable () -> Unit,
+    action: @Composable (() -> Unit)? = null,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        AttributionLayout(
+            modifier = Modifier.fillMaxWidth(),
+            avatar = avatar,
+            label = {
+                // Renders identically to RecordLayout's title/subtitle
+                // but without PaneStickySharedElement wrapping —
+                // bottom sheets are separate windows and cannot
+                // participate in shared element transitions
+                RecordTitle(title = title)
+                RecordSubtitle(subtitle = subtitle)
+            },
+            action = action,
+        )
+        description.takeUnless(String?::isNullOrEmpty)?.let {
+            RecordText(text = it)
+        }
+        blurb.takeUnless(String?::isNullOrEmpty)?.let {
+            RecordBlurb(blurb = it)
+        }
+    }
+}
+
+private val ListMemberChipShape = RoundedCornerShape(16.dp)

--- a/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/utilities/WriteQueueStatusMemos.kt
+++ b/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/utilities/WriteQueueStatusMemos.kt
@@ -53,6 +53,7 @@ import heron.ui.timeline.generated.resources.writable_unblock
 import heron.ui.timeline.generated.resources.writable_unfollow
 import heron.ui.timeline.generated.resources.writable_unlike
 import heron.ui.timeline.generated.resources.writable_unmute
+import heron.ui.timeline.generated.resources.writable_update_created_list_members
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 import org.jetbrains.compose.resources.StringResource
@@ -165,10 +166,6 @@ fun Writable.writeStatusMessage(
                 stringResource = genericDroppedOrDuplicateResource(isDropped),
                 args = listOf(Res.string.writable_record_deletion),
             )
-            is Writable.FeedList.AddMember -> Memo.Resource(
-                stringResource = genericDroppedOrDuplicateResource(isDropped),
-                args = listOf(Res.string.writable_add_list_member),
-            )
             is Writable.StandardSite.Subscribe -> Memo.Resource(
                 stringResource = genericDroppedOrDuplicateResource(isDropped),
                 args = listOf(Res.string.writable_subscribe_standard_publication),
@@ -177,6 +174,16 @@ fun Writable.writeStatusMessage(
                 stringResource = genericDroppedOrDuplicateResource(isDropped),
                 args = listOf(Res.string.writable_profile_status_update),
             )
+            is Writable.FeedList -> {
+                val stringResource = when (this) {
+                    is Writable.FeedList.AddMember -> Res.string.writable_add_list_member
+                    is Writable.FeedList.UpdateCreatedListMembers -> Res.string.writable_update_created_list_members
+                }
+                Memo.Resource(
+                    stringResource = genericDroppedOrDuplicateResource(isDropped),
+                    args = listOf(stringResource),
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## What
Allows a signed-in user to add or remove any profile from their own lists directly from the profile screen, via a bottom sheet picker.

## Changes

### UI
- Added a new entry in `ProfileActionsMenu` to trigger the list membership editor
- Implemented `ListMemberPickerBottomSheet` shows the signed-in user's lists with a `FilterChip` per item indicating current membership status (Add/Remove)
- `ListMemberPickerItem` uses `RecordLayout` with `ListMembershipChip` driven by a nullable `ListMember?`  presence means member, null means not

### Data
- Added `membershipsByProfile(profileId)` DAO query on `listMembers` table scoped to a subject profile
- Implemented `membershipsByProfile` in the repository using `singleAuthorizedSessionFlow`, returning `Flow<List<ListMember>>` for the viewed profile

### ViewModel / State
- Added `profileListMemberships: List<ListMember>` and `signedInProfileListsHolder` to `State`
- `loadProfileMutations` now uses `flatMapLatest` to resolve `profile.did` before fetching memberships avoids unsafe `ProfileHandleOrId` cast
- Added `Action.AddListMember` with a corresponding `enqueueMutation` writing `FeedList.AddMember` to the `WriteQueue`
- Removal reuses the existing `Action.DeleteRecord` since `ListMemberUri` is a `RecordUri`

## Why
The lists data was already loaded per profile tab via `ProfileScreenStateHolders.Records.Lists`  the signed-in user's lists are sourced from a dedicated `signedInProfileListsHolder` so the correct lists always appear regardless of which profile is being viewed.

## Demo

https://github.com/user-attachments/assets/ce2cd9fa-4e8e-40b2-8357-8186e362c1f3

