### PR TITLE
Trigger network refresh for recentLists flow

### DIFF
--- a/data/core/src/commonMain/kotlin/com/tunjid/heron/data/repository/records/BlueskyRecordOperations.kt
+++ b/data/core/src/commonMain/kotlin/com/tunjid/heron/data/repository/records/BlueskyRecordOperations.kt
@@ -91,6 +91,7 @@ import com.tunjid.heron.data.utilities.nextCursorFlow
 import com.tunjid.heron.data.utilities.profileLookup.ProfileLookup
 import com.tunjid.heron.data.utilities.recordResolver.RecordResolver
 import com.tunjid.heron.data.utilities.toOutcome
+import com.tunjid.heron.data.utilities.withRefresh
 import dev.zacsweers.metro.Inject
 import kotlin.time.Clock
 import kotlinx.coroutines.CoroutineDispatcher
@@ -174,6 +175,21 @@ internal class OfflineFirstBlueskyRecordOperations @Inject constructor(
                 limit = 30,
                 offset = 0,
             ).distinctUntilChangedMap { it.map(PopulatedListEntity::asExternalModel) }
+                .withRefresh {
+                    networkService.runCatchingWithMonitoredNetworkRetry {
+                        getLists(
+                            params = GetListsQueryParams(
+                                actor = profileId.id.let(::Did),
+                                limit = 30,
+                                cursor = null,
+                            ),
+                        )
+                    }.mapCatchingUnlessCancelled { response ->
+                        multipleEntitySaverProvider.saveInTransaction {
+                            response.lists.forEach(::add)
+                        }
+                    }
+                }
         }
             .flowOn(ioDispatcher)
             .stateIn(

--- a/data/core/src/commonMain/kotlin/com/tunjid/heron/data/repository/records/BlueskyRecordOperations.kt
+++ b/data/core/src/commonMain/kotlin/com/tunjid/heron/data/repository/records/BlueskyRecordOperations.kt
@@ -180,12 +180,13 @@ internal class OfflineFirstBlueskyRecordOperations @Inject constructor(
                         getLists(
                             params = GetListsQueryParams(
                                 actor = profileId.id.let(::Did),
-                                limit = 30,
+                                limit = 50,
                                 cursor = null,
                             ),
                         )
                     }.mapCatchingUnlessCancelled { response ->
                         multipleEntitySaverProvider.saveInTransaction {
+                            listDao.deleteListsForCreator(profileId.id)
                             response.lists.forEach(::add)
                         }
                     }


### PR DESCRIPTION
Integrate `withRefresh` into `recentLists` to ensure local DB is populated from network when the flow is collected. Fixes empty list selection in post composer and interaction settings in Moderation.

Fixes: https://github.com/tunjid/heron/issues/1238