### PR TITLE
Show and apply provider handle suffix in sign-in

### DIFF
--- a/feature/auth/src/commonMain/kotlin/com/tunjid/heron/signin/SignInScreen.kt
+++ b/feature/auth/src/commonMain/kotlin/com/tunjid/heron/signin/SignInScreen.kt
@@ -126,8 +126,7 @@ internal fun SignInScreen(
                                     )
                                 }
                             }
-                        }
-                        else null,
+                        } else null,
                         onValueChange = { field, newValue ->
                             actions(
                                 Action.FieldChanged(

--- a/feature/auth/src/commonMain/kotlin/com/tunjid/heron/signin/SignInScreen.kt
+++ b/feature/auth/src/commonMain/kotlin/com/tunjid/heron/signin/SignInScreen.kt
@@ -31,6 +31,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.key
@@ -114,11 +116,24 @@ internal fun SignInScreen(
                                 mostRecentSession = state.mostRecentSession,
                             )
                         },
+                        suffix = if (field.id == Username) {
+                            {
+                                state.profileHandleSuffix?.let { handleSuffix ->
+                                    Text(
+                                        text = handleSuffix,
+                                        style = MaterialTheme.typography.bodyLarge,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                }
+                            }
+                        }
+                        else null,
                         onValueChange = { field, newValue ->
                             actions(
                                 Action.FieldChanged(
                                     id = field.id,
                                     text = newValue,
+                                    selectedServer = state.selectedServer,
                                 ),
                             )
                         },
@@ -142,6 +157,7 @@ internal fun SignInScreen(
                             Action.FieldChanged(
                                 id = Username,
                                 text = field.value,
+                                selectedServer = state.selectedServer,
                             ),
                         )
                     }

--- a/feature/auth/src/commonMain/kotlin/com/tunjid/heron/signin/SignInStateHolder.kt
+++ b/feature/auth/src/commonMain/kotlin/com/tunjid/heron/signin/SignInStateHolder.kt
@@ -178,13 +178,19 @@ private fun Flow<Action.FieldChanged>.formEditMutations(
         replay = 1,
     )
     return merge(
-        shared.mapToMutation { (id, text) ->
+        shared.mapToMutation { (id, text, _) ->
             copy(fields = fields.copyWithValidation(id, text))
         },
-        shared.filter { it.id == Username && DomainRegex.matches(it.text) }
+        shared.filter { (id, text, selectedServer) ->
+            id == Username && DomainRegex.matches(
+                text.normalizedProfileHandle(server = selectedServer).id,
+            )
+        }
             .debounce(HandleResolutionDebounceMs)
-            .mapLatestToManyMutations { (_, text) ->
-                val server = authRepository.resolveServer(ProfileHandle(text))
+            .mapLatestToManyMutations { (_, text, selectedServer) ->
+                val server = authRepository.resolveServer(
+                    text.normalizedProfileHandle(server = selectedServer),
+                )
                     .getOrNull()
                     ?.normalized()
 

--- a/feature/auth/src/commonMain/kotlin/com/tunjid/heron/signin/State.kt
+++ b/feature/auth/src/commonMain/kotlin/com/tunjid/heron/signin/State.kt
@@ -42,7 +42,6 @@ import heron.feature.auth.generated.resources.Res
 import heron.feature.auth.generated.resources.at_sign_not_allowed
 import heron.feature.auth.generated.resources.empty_form
 import heron.feature.auth.generated.resources.invalid_handle
-import heron.feature.auth.generated.resources.missing_domain
 import heron.feature.auth.generated.resources.password
 import heron.feature.auth.generated.resources.username
 import kotlinx.serialization.Serializable
@@ -51,12 +50,15 @@ import kotlinx.serialization.Transient
 internal val Username = FormField.Id("username")
 internal val Password = FormField.Id("password")
 
+internal val HandleLabelRegex = Regex(
+    pattern = "^(?!-)[A-Za-z0-9-]{1,63}(?<!-)$",
+)
+
 internal val DomainRegex = Regex(
     pattern = "^((?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)+(?!-)[A-Za-z0-9-]{2,63}(?<!-)\$",
 )
 
 private fun String.hasNoAtSign() = !contains('@')
-private fun String.hasDomain() = contains('.')
 
 internal val StartingServers = Server.KnownServers.toList() +
     Server(
@@ -117,10 +119,7 @@ internal val InitialFields: List<FormField> = listOf(
             String::hasNoAtSign to Memo.Resource(
                 Res.string.at_sign_not_allowed,
             ),
-            String::hasDomain to Memo.Resource(
-                Res.string.missing_domain,
-            ),
-            DomainRegex::matches to Memo.Resource(
+            ::isValidHandleInput to Memo.Resource(
                 Res.string.invalid_handle,
             ),
         ),
@@ -155,7 +154,16 @@ val State.canSwitchAccount: Boolean
     get() = isSignedIn && pastSessions.isNotEmpty()
 
 val State.profileHandle: ProfileHandle
-    get() = ProfileHandle(id = fields.valueFor(Username))
+    get() = fields.valueFor(Username)
+        .normalizedProfileHandle(server = selectedServer)
+
+val State.profileHandleSuffix: String?
+    get() = fields
+        .valueFor(Username)
+        ?.takeIf { it.isNotBlank() }
+        ?.takeUnless { '.' in it }
+        ?.let { selectedServer.defaultHandleDomain }
+        ?.let { ".$it" }
 
 val State.canSignInLater: Boolean
     get() = fields.all { field ->
@@ -206,6 +214,7 @@ sealed class Action(val key: String) {
     data class FieldChanged(
         val id: FormField.Id,
         val text: String,
+        val selectedServer: Server,
     ) : Action("FieldChanged")
 
     data class OauthAvailabilityChanged(
@@ -240,3 +249,31 @@ sealed class Action(val key: String) {
         Action(key = "Navigate"),
         NavigationAction
 }
+
+internal fun isValidHandleInput(input: String): Boolean = when {
+    input.isBlank() -> false
+    '.' in input -> DomainRegex.matches(input)
+    else -> HandleLabelRegex.matches(input)
+}
+
+internal fun String.normalizedProfileHandle(
+    server: Server,
+): ProfileHandle = ProfileHandle(
+    id = if ('.' in this) this
+    else server.defaultHandleDomain
+        ?.let { "$this.$it" }
+        ?: this,
+)
+
+private val Server.defaultHandleDomain: String?
+    get() = endpoint
+        .takeIf {
+            it in setOf(
+                Server.BlueSky.endpoint,
+                Server.BlackSky.endpoint,
+                Server.EuroSky.endpoint,
+                Server.Pckt.endpoint,
+            )
+        }
+        ?.removePrefix("https://")
+        ?.removePrefix("http://")

--- a/feature/auth/src/commonMain/kotlin/com/tunjid/heron/signin/State.kt
+++ b/feature/auth/src/commonMain/kotlin/com/tunjid/heron/signin/State.kt
@@ -275,5 +275,5 @@ private val Server.defaultHandleDomain: String?
                 Server.Pckt.endpoint,
             )
         }
-        ?.removePrefix("https://")
-        ?.removePrefix("http://")
+        ?.substringAfter("://")
+        ?.removeSuffix("/")

--- a/ui/core/src/commonMain/kotlin/com/tunjid/heron/ui/text/Forms.kt
+++ b/ui/core/src/commonMain/kotlin/com/tunjid/heron/ui/text/Forms.kt
@@ -129,6 +129,7 @@ inline fun FormField(
     crossinline leadingIcon: @Composable () -> Unit = {
         field.LeadingIcon()
     },
+    noinline suffix: @Composable (() -> Unit)? = null,
     crossinline onValueChange: (field: FormField, newValue: String) -> Unit,
     crossinline keyboardActions: KeyboardActionScope.(FormField) -> Unit,
 ) {
@@ -161,6 +162,7 @@ inline fun FormField(
         leadingIcon = {
             leadingIcon()
         },
+        suffix = suffix,
         supportingText = if (showError) field.errorMessage.let {
             {
                 Text(


### PR DESCRIPTION

## Summary
- Resolved #1220 
- append the selected provider's default handle suffix when users enter only a username
- preserve fully qualified handles as-is
- show the inferred suffix inline in the sign-in field for both OAuth and password flows

[Screen_recording_20260422_212746.webm](https://github.com/user-attachments/assets/44c0799e-2df6-4785-ad2b-6b7857c67a1e)
