### PR TITLE
Embed Record links when composing a post 

### DIFF
--- a/data/models/src/commonMain/kotlin/com/tunjid/heron/data/core/types/Uri.kt
+++ b/data/models/src/commonMain/kotlin/com/tunjid/heron/data/core/types/Uri.kt
@@ -365,10 +365,14 @@ fun String.asRecordUriOrNull(): RecordUri? = atUriComponents { _, collectionRang
     }
 }
 
-fun String.asEmbeddableRecordUriOrNull(): EmbeddableRecordUri? =
-    atUriComponents { _, collectionRange, _ ->
-        val normalized = withAtProtoPrefix()
-        when (substring(collectionRange.start, collectionRange.endExclusive)) {
+fun String.asEmbeddableRecordUriOrNull(): EmbeddableRecordUri? {
+    val atUri = when {
+        startsWith(Uri.Host.Https.prefix) -> bskyHttpsUrlToAtUri() ?: return null
+        else -> this
+    }
+    return atUri.atUriComponents { _, collectionRange, _ ->
+        val normalized = atUri.withAtProtoPrefix()
+        when (atUri.substring(collectionRange.start, collectionRange.endExclusive)) {
             PostUri.NAMESPACE -> PostUri(normalized)
             FeedGeneratorUri.NAMESPACE -> FeedGeneratorUri(normalized)
             ListUri.NAMESPACE -> ListUri(normalized)
@@ -377,10 +381,42 @@ fun String.asEmbeddableRecordUriOrNull(): EmbeddableRecordUri? =
             else -> null
         }
     }
+}
 
 private fun String.withAtProtoPrefix(): String =
     if (startsWith(Uri.Host.AtProto.prefix)) this
     else "${Uri.Host.AtProto.prefix}$this"
+
+private val bskyPathSegmentToNamespace = mapOf(
+    "post" to PostUri.NAMESPACE,
+    "feed" to FeedGeneratorUri.NAMESPACE,
+    "lists" to ListUri.NAMESPACE,
+    "starter-pack" to StarterPackUri.NAMESPACE,
+    "labeler" to LabelerUri.NAMESPACE,
+)
+
+fun String.bskyHttpsUrlToAtUri(): String? {
+    if (!startsWith(Uri.Host.Https.prefix)) return null
+    val segments = removePrefix(Uri.Host.Https.prefix)
+        .removePrefix("bsky.app/")
+        .split("/")
+
+    val (handle, type, rkey) = when (segments.size) {
+        4 -> when (segments[0]) {
+            "profile" -> Triple(segments[1], segments[2], segments[3])
+            else -> return null
+        }
+        3 -> when (segments[0]) {
+            "starter-pack" -> Triple(segments[1], segments[0], segments[2])
+            "profile" -> Triple(segments[1], segments[2], "self") // labeler
+            else -> return null
+        }
+        else -> return null
+    }
+
+    val namespace = bskyPathSegmentToNamespace[type] ?: return null
+    return "${Uri.Host.AtProto.prefix}$handle/$namespace/$rkey"
+}
 
 /**
  * Parses an AT URI string into its components without using Regex or intermediate data classes.

--- a/data/models/src/commonMain/kotlin/com/tunjid/heron/data/core/types/Uri.kt
+++ b/data/models/src/commonMain/kotlin/com/tunjid/heron/data/core/types/Uri.kt
@@ -397,28 +397,51 @@ private val bskyPathSegmentToNamespace = mapOf(
 
 fun String.bskyHttpsUrlToAtUri(): String? {
     if (!startsWith(Uri.Host.Https.prefix)) return null
-    val segments = removePrefix(Uri.Host.Https.prefix)
-        .removePrefix("www.")
-        .removePrefix("bsky.app/")
-        .split("/")
-        .filter { it.isNotEmpty() }
 
-    val (handle, type, rkey) = when (segments.size) {
-        4 -> when (segments[0]) {
-            "profile" -> Triple(segments[1], segments[2], segments[3])
-            else -> return null
-        }
-        3 -> when (segments[0]) {
-            "starter-pack" -> Triple(segments[1], segments[0], segments[2])
-            "profile" -> Triple(segments[1], segments[2], "self") // labeler
-            else -> return null
-        }
+    // Skip past "https://" and optional "www."
+    var cursor = Uri.Host.Https.prefix.length
+    if (startsWith("www.", cursor)) cursor += 4
+
+    // Must start with "bsky.app/"
+    if (!startsWith("bsky.app/", cursor)) return null
+    cursor += "bsky.app/".length
+
+    // Find first segment
+    val seg0End = indexOf('/', cursor).takeIf { it != -1 } ?: return null
+    val seg0 = substring(cursor, seg0End)
+
+    // Find second segment
+    val seg1Start = seg0End + 1
+    val seg1End = indexOf('/', seg1Start).takeIf { it != -1 } ?: return null
+    val seg1 = substring(seg1Start, seg1End)
+
+    // Find third segment — stop at '?', '#' or end of string
+    val seg2Start = seg1End + 1
+    val seg2End = indexOfFirst(seg2Start) { it == '/' || it == '?' || it == '#' }
+        .takeIf { it != -1 } ?: length
+    val seg2 = substring(seg2Start, seg2End)
+
+    // Find optional fourth segment
+    val seg3End = if (seg2End < length && this[seg2End] == '/') {
+        indexOfFirst(seg2End + 1) { it == '?' || it == '#' }
+            .takeIf { it != -1 } ?: length
+    } else -1
+    val seg3 = if (seg3End != -1) substring(seg2End + 1, seg3End) else null
+
+    val (handle, type, rkey) = when {
+        seg0 == "profile" && seg3 != null -> Triple(seg1, seg2, seg3)
+        seg0 == "starter-pack" -> Triple(seg1, seg0, seg2)
+        seg0 == "profile" -> Triple(seg1, seg2, "self") // labeler
         else -> return null
     }
 
     val namespace = bskyPathSegmentToNamespace[type] ?: return null
-    val cleanRkey = rkey.substringBefore('?').substringBefore('#')
-    return "${Uri.Host.AtProto.prefix}$handle/$namespace/$cleanRkey"
+    return "${Uri.Host.AtProto.prefix}$handle/$namespace/$rkey"
+}
+
+private inline fun String.indexOfFirst(startIndex: Int, predicate: (Char) -> Boolean): Int {
+    for (i in startIndex until length) if (predicate(this[i])) return i
+    return -1
 }
 
 /**

--- a/data/models/src/commonMain/kotlin/com/tunjid/heron/data/core/types/Uri.kt
+++ b/data/models/src/commonMain/kotlin/com/tunjid/heron/data/core/types/Uri.kt
@@ -398,8 +398,10 @@ private val bskyPathSegmentToNamespace = mapOf(
 fun String.bskyHttpsUrlToAtUri(): String? {
     if (!startsWith(Uri.Host.Https.prefix)) return null
     val segments = removePrefix(Uri.Host.Https.prefix)
+        .removePrefix("www.")
         .removePrefix("bsky.app/")
         .split("/")
+        .filter { it.isNotEmpty() }
 
     val (handle, type, rkey) = when (segments.size) {
         4 -> when (segments[0]) {
@@ -415,7 +417,8 @@ fun String.bskyHttpsUrlToAtUri(): String? {
     }
 
     val namespace = bskyPathSegmentToNamespace[type] ?: return null
-    return "${Uri.Host.AtProto.prefix}$handle/$namespace/$rkey"
+    val cleanRkey = rkey.substringBefore('?').substringBefore('#')
+    return "${Uri.Host.AtProto.prefix}$handle/$namespace/$cleanRkey"
 }
 
 /**

--- a/feature/compose/src/commonMain/kotlin/com/tunjid/heron/compose/ComposeScreen.kt
+++ b/feature/compose/src/commonMain/kotlin/com/tunjid/heron/compose/ComposeScreen.kt
@@ -124,6 +124,11 @@ internal fun ComposeScreen(
             onRemoveEmbeddedRecordClicked = {
                 actions(Action.RemoveEmbeddedRecord)
             },
+            onExternalLinkDetected = {
+                if (state.embeddedRecord == null) {
+                    actions(Action.EmbedUrl(it))
+                }
+            },
         )
         if (state.suggestedProfiles.isNotEmpty()) {
             ProfileSearchResults(
@@ -176,6 +181,7 @@ private fun Post(
     onPostTextChanged: (TextFieldValue) -> Unit,
     onMentionDetected: (String) -> Unit,
     onRemoveEmbeddedRecordClicked: () -> Unit,
+    onExternalLinkDetected: (String) -> Unit,
 ) {
     Column(
         modifier = modifier,
@@ -203,6 +209,7 @@ private fun Post(
                     postText = postText,
                     onPostTextChanged = onPostTextChanged,
                     onMentionDetected = onMentionDetected,
+                    onExternalLinkDetected = onExternalLinkDetected,
                 )
             },
         )
@@ -328,6 +335,7 @@ private fun PostComposition(
     postText: TextFieldValue,
     onPostTextChanged: (TextFieldValue) -> Unit,
     onMentionDetected: (String) -> Unit,
+    onExternalLinkDetected: (String) -> Unit,
 ) {
     val textFieldFocusRequester = remember { FocusRequester() }
     val bringIntoViewRequester = remember { BringIntoViewRequester() }
@@ -349,6 +357,7 @@ private fun PostComposition(
             )
             when (val target = links.detectActiveLink(it.selection)) {
                 is LinkTarget.UserHandleMention -> onMentionDetected(target.handle.id)
+                is LinkTarget.ExternalLink -> onExternalLinkDetected(target.uri.uri)
                 is LinkTarget.Hashtag -> {
                     // TODO: Implement hashtag search
                 }

--- a/feature/compose/src/commonMain/kotlin/com/tunjid/heron/compose/ComposeScreen.kt
+++ b/feature/compose/src/commonMain/kotlin/com/tunjid/heron/compose/ComposeScreen.kt
@@ -40,8 +40,11 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -101,6 +104,7 @@ internal fun ComposeScreen(
     actions: (Action) -> Unit,
 ) {
     val scrollState = rememberScrollState()
+    var lastDetectedEmbedUrl by remember { mutableStateOf<String?>(null) }
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -122,11 +126,12 @@ internal fun ComposeScreen(
                 actions(Action.SearchProfiles(it))
             },
             onRemoveEmbeddedRecordClicked = {
-                actions(Action.RemoveEmbeddedRecord)
+                actions(Action.RemoveEmbeddedRecord(lastDetectedEmbedUrl))
             },
-            onExternalLinkDetected = {
-                if (state.embeddedRecord == null) {
-                    actions(Action.EmbedUrl(it))
+            onExternalLinkDetected = { url ->
+                lastDetectedEmbedUrl = url
+                if (state.embeddedRecord == null && state.dismissedEmbedUrl != url) {
+                    actions(Action.EmbedUrl(url))
                 }
             },
         )

--- a/feature/compose/src/commonMain/kotlin/com/tunjid/heron/compose/ComposeViewModel.kt
+++ b/feature/compose/src/commonMain/kotlin/com/tunjid/heron/compose/ComposeViewModel.kt
@@ -176,15 +176,16 @@ private fun embeddedRecordMutations(
 private fun Flow<Action.EmbedUrl>.embedUrlMutations(
     recordRepository: RecordRepository,
 ): Flow<Mutation<State>> =
-    mapLatestToManyMutations { action ->
-        val uri = action.url.asEmbeddableRecordUriOrNull() ?: return@mapLatestToManyMutations
-        emitAll(
-            embeddedRecordMutations(
-                embeddedRecordUri = uri,
-                recordRepository = recordRepository,
-            ),
-        )
-    }
+    debounce(400.milliseconds)
+        .mapLatestToManyMutations { action ->
+            val uri = action.url.asEmbeddableRecordUriOrNull() ?: return@mapLatestToManyMutations
+            emitAll(
+                embeddedRecordMutations(
+                    embeddedRecordUri = uri,
+                    recordRepository = recordRepository,
+                ),
+            )
+        }
 
 private fun Flow<Action.PostTextChanged>.postTextMutations(): Flow<Mutation<State>> =
     mapToMutation { action ->
@@ -203,7 +204,10 @@ private fun Flow<Action.SnackbarDismissed>.snackbarDismissalMutations(): Flow<Mu
 
 private fun Flow<Action.RemoveEmbeddedRecord>.removeEmbeddedMutations(): Flow<Mutation<State>> =
     mapToMutation {
-        copy(embeddedRecord = null)
+        copy(
+            embeddedRecord = null,
+            dismissedEmbedUrl = it.url,
+        )
     }
 
 private fun Flow<Action.UpdateInteractionSettings>.updateInteractionSettingsMutations(): Flow<Mutation<State>> =

--- a/feature/compose/src/commonMain/kotlin/com/tunjid/heron/compose/ComposeViewModel.kt
+++ b/feature/compose/src/commonMain/kotlin/com/tunjid/heron/compose/ComposeViewModel.kt
@@ -44,6 +44,7 @@ import com.tunjid.heron.ui.text.Memo
 import com.tunjid.mutator.ActionStateMutator
 import com.tunjid.mutator.Mutation
 import com.tunjid.mutator.coroutines.actionStateFlowMutator
+import com.tunjid.mutator.coroutines.mapLatestToManyMutations
 import com.tunjid.mutator.coroutines.mapToManyMutations
 import com.tunjid.mutator.coroutines.mapToMutation
 import com.tunjid.mutator.coroutines.toMutationStream
@@ -139,6 +140,9 @@ class ActualComposeViewModel(
                     is Action.UpdateRecentLists -> action.flow.recentListsMutations(
                         recordRepository = recordRepository,
                     )
+                    is Action.EmbedUrl -> action.flow.embedUrlMutations(
+                        recordRepository = recordRepository,
+                    )
                 }
             }
         },
@@ -168,6 +172,19 @@ private fun embeddedRecordMutations(
         }
     }
         ?: emptyFlow()
+
+private fun Flow<Action.EmbedUrl>.embedUrlMutations(
+    recordRepository: RecordRepository,
+): Flow<Mutation<State>> =
+    mapLatestToManyMutations { action ->
+        val uri = action.url.asEmbeddableRecordUriOrNull() ?: return@mapLatestToManyMutations
+        emitAll(
+            embeddedRecordMutations(
+                embeddedRecordUri = uri,
+                recordRepository = recordRepository,
+            ),
+        )
+    }
 
 private fun Flow<Action.PostTextChanged>.postTextMutations(): Flow<Mutation<State>> =
     mapToMutation { action ->

--- a/feature/compose/src/commonMain/kotlin/com/tunjid/heron/compose/ComposeViewModel.kt
+++ b/feature/compose/src/commonMain/kotlin/com/tunjid/heron/compose/ComposeViewModel.kt
@@ -69,6 +69,7 @@ import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.withContext
 
 internal typealias ComposeStateHolder = ActionStateMutator<Action, StateFlow<State>>
@@ -180,10 +181,9 @@ private fun Flow<Action.EmbedUrl>.embedUrlMutations(
         .mapLatestToManyMutations { action ->
             val uri = action.url.asEmbeddableRecordUriOrNull() ?: return@mapLatestToManyMutations
             emitAll(
-                embeddedRecordMutations(
-                    embeddedRecordUri = uri,
-                    recordRepository = recordRepository,
-                ),
+                recordRepository.embeddableRecord(uri)
+                    .take(1)
+                    .mapToMutation { copy(embeddedRecord = it) },
             )
         }
 

--- a/feature/compose/src/commonMain/kotlin/com/tunjid/heron/compose/State.kt
+++ b/feature/compose/src/commonMain/kotlin/com/tunjid/heron/compose/State.kt
@@ -100,6 +100,10 @@ sealed class Action(val key: String) {
         val textFieldValue: TextFieldValue,
     ) : Action("PostTextChanged")
 
+    data class EmbedUrl(
+        val url: String,
+    ) : Action("EmbedUrl")
+
     data class CreatePost(
         val postType: Post.Create?,
         val authorId: ProfileId,

--- a/feature/compose/src/commonMain/kotlin/com/tunjid/heron/compose/State.kt
+++ b/feature/compose/src/commonMain/kotlin/com/tunjid/heron/compose/State.kt
@@ -44,6 +44,8 @@ data class State(
     val fabExpanded: Boolean = true,
     val embeddedRecord: Record.Embeddable? = null,
     @Transient
+    val dismissedEmbedUrl: String? = null,
+    @Transient
     val recentLists: List<FeedList> = emptyList(),
     @Transient
     val interactionsPreference: PostInteractionSettingsPreference? = null,
@@ -154,7 +156,9 @@ sealed class Action(val key: String) {
 
     data object ClearSuggestions : Action("ClearSuggestions")
 
-    data object RemoveEmbeddedRecord : Action("RemoveEmbeddedRecord")
+    data class RemoveEmbeddedRecord(
+        val url: String? = null,
+    ) : Action("RemoveEmbeddedRecord")
 
     data object UpdateRecentLists : Action("UpdateRecentLists")
 }


### PR DESCRIPTION
Pasting a bsky.app link while composing a post or reply now automatically embeds the linked record matching the behaviour in the official Bluesky app.

What changed
- `bskyHttpsUrlToAtUri()` converts any `https://bsky.app/`. URL to its `at://` equivalent, covering posts, feeds, lists, starter packs and labelers
- `asEmbeddableRecordUriOrNull()`  now handles both `https://` and `at://` inputs, so the rest of the pipeline needs no special casing
- `PostComposition` scans all parsed links for any ExternalLink and surfaces it via `onExternalLinkDetected`
- `Action.EmbedUrl` + `embedUrlMutations` resolves the URL through `recordRepository.embeddableRecord()` and updates `state.embeddedRecord`
- `ComposeScreen` wires `onExternalLinkDetected` to dispatch `Action.EmbedUrl`, guarded against overwriting an already embedded record

## Demo

https://github.com/user-attachments/assets/e0045e23-da57-4af5-a6fb-db1439a398e8

