### PR TITLE
Fixes for rocksky operations

### DIFF
--- a/data/core/src/commonMain/kotlin/com/tunjid/heron/data/utilities/atmosphereintegration/AtmosphereApps.kt
+++ b/data/core/src/commonMain/kotlin/com/tunjid/heron/data/utilities/atmosphereintegration/AtmosphereApps.kt
@@ -33,11 +33,11 @@ internal val SupportedAtmosphereApps: List<AtmosphereApp> = listOf(
         logo = ImageUri("https://standard.site/favicon.ico"),
     ),
     // Uncomment for development, undercooked for now
-//    AtmosphereApp(
-//        id = AtmosphereApp.RockskyId,
-//        webpage = GenericUri("https://rocksky.app"),
-//        logo = ImageUri("https://rocksky.app/favicon.ico"),
-//    ),
+    AtmosphereApp(
+        id = AtmosphereApp.RockskyId,
+        webpage = GenericUri("https://rocksky.app"),
+        logo = ImageUri("https://rocksky.app/favicon.ico"),
+    ),
 )
 
 internal val AtmosphereAppNsids: Map<String, List<String>> = mapOf(

--- a/data/core/src/commonMain/kotlin/com/tunjid/heron/data/utilities/multipleEntitysaver/MultipleEntitySaver.kt
+++ b/data/core/src/commonMain/kotlin/com/tunjid/heron/data/utilities/multipleEntitysaver/MultipleEntitySaver.kt
@@ -417,16 +417,16 @@ internal class MultipleEntitySaver(
         }
 
         if (rockskyArtistEntities.isNotEmpty) {
-            rockskyDao.upsertArtists(rockskyArtistEntities.list)
+            rockskyDao.insertOrPartiallyUpdateArtists(rockskyArtistEntities.list)
         }
         if (rockskyAlbumEntities.isNotEmpty) {
-            rockskyDao.upsertAlbums(rockskyAlbumEntities.list)
-        }
-        if (rockskyScrobbleEntities.isNotEmpty) {
-            rockskyDao.upsertScrobbles(rockskyScrobbleEntities.list)
+            rockskyDao.insertOrPartiallyUpdateAlbums(rockskyAlbumEntities.list)
         }
         if (rockskyTrackEntities.isNotEmpty) {
-            rockskyDao.upsertTracks(rockskyTrackEntities.list)
+            rockskyDao.insertOrPartiallyUpdateTracks(rockskyTrackEntities.list)
+        }
+        if (rockskyScrobbleEntities.isNotEmpty) {
+            rockskyDao.insertOrPartiallyUpdateScrobbles(rockskyScrobbleEntities.list)
         }
 
         if (threadGateEntities.isNotEmpty) {

--- a/data/core/src/commonMain/kotlin/com/tunjid/heron/data/utilities/multipleEntitysaver/SaveRockskyAlbumView.kt
+++ b/data/core/src/commonMain/kotlin/com/tunjid/heron/data/utilities/multipleEntitysaver/SaveRockskyAlbumView.kt
@@ -14,6 +14,18 @@ internal fun MultipleEntitySaver.add(
     albumView: AlbumView,
 ) {
     add(stubProfileEntity(Did(creatorId.id)))
+
+    val artistUri = ArtistUri(albumView.artistUri.atUri)
+    val albumArt = albumView.albumArt?.let { ImageUri(it.uri) }
+
+    add(
+        stubRockskyArtistEntity(
+            uri = artistUri,
+            creatorId = creatorId,
+            name = albumView.artist,
+        ),
+    )
+
     add(
         RockskyAlbumEntity(
             uri = AlbumUri(albumView.uri.atUri),
@@ -23,8 +35,8 @@ internal fun MultipleEntitySaver.add(
             artist = albumView.artist,
             releaseDate = albumView.releaseDate,
             year = albumView.year?.toInt(),
-            albumArt = albumView.albumArt?.let { ImageUri(it.uri) },
-            artistUri = ArtistUri(albumView.artistUri.atUri),
+            albumArt = albumArt,
+            artistUri = artistUri,
             playCount = albumView.playCount,
             uniqueListeners = albumView.uniqueListeners,
             appleMusicLink = albumView.appleMusicLink?.uri,

--- a/data/core/src/commonMain/kotlin/com/tunjid/heron/data/utilities/multipleEntitysaver/SaveRockskyScrobbleView.kt
+++ b/data/core/src/commonMain/kotlin/com/tunjid/heron/data/utilities/multipleEntitysaver/SaveRockskyScrobbleView.kt
@@ -18,6 +18,56 @@ internal fun MultipleEntitySaver.add(
     scrobbleView: ScrobbleView,
 ) {
     add(stubProfileEntity(Did(creatorId.id)))
+
+    val artistUri = scrobbleView.artistUri?.let { ArtistUri(it.atUri) }
+    val trackUri = scrobbleView.trackUri?.let { TrackUri(it.atUri) }
+    val albumArt = scrobbleView.albumArt?.let { ImageUri(it.uri) }
+    // Album requires a non-null artistUri FK; if we don't have one, drop the
+    // scrobble's albumUri rather than stubbing an album we can't satisfy.
+    val albumUri = scrobbleView.albumUri
+        ?.takeIf { artistUri != null }
+        ?.let { AlbumUri(it.atUri) }
+
+    if (artistUri != null) {
+        add(
+            stubRockskyArtistEntity(
+                uri = artistUri,
+                creatorId = creatorId,
+                name = scrobbleView.artist,
+            ),
+        )
+    }
+
+    if (albumUri != null && artistUri != null) {
+        add(
+            stubRockskyAlbumEntity(
+                uri = albumUri,
+                creatorId = creatorId,
+                artistUri = artistUri,
+                title = scrobbleView.album ?: scrobbleView.title,
+                artist = scrobbleView.albumArtist ?: scrobbleView.artist,
+                albumArt = albumArt,
+            ),
+        )
+    }
+
+    if (trackUri != null) {
+        add(
+            stubRockskyTrackEntity(
+                uri = trackUri,
+                cid = TrackId(scrobbleView.trackId),
+                creatorId = creatorId,
+                title = scrobbleView.title,
+                artist = scrobbleView.artist,
+                albumArtist = scrobbleView.albumArtist,
+                album = scrobbleView.album,
+                albumArt = albumArt,
+                albumUri = albumUri,
+                artistUri = artistUri,
+            ),
+        )
+    }
+
     add(
         RockskyScrobbleEntity(
             uri = ScrobbleUri(scrobbleView.uri.atUri),
@@ -28,13 +78,13 @@ internal fun MultipleEntitySaver.add(
             artist = scrobbleView.artist,
             albumArtist = scrobbleView.albumArtist,
             album = scrobbleView.album,
-            albumArt = scrobbleView.albumArt?.let { ImageUri(it.uri) },
+            albumArt = albumArt,
             handle = scrobbleView.handle?.let { ProfileHandle(it.handle) },
             did = ProfileId(scrobbleView.did.did),
             avatar = scrobbleView.avatar?.let { ImageUri(it.uri) },
-            trackUri = scrobbleView.trackUri?.let { TrackUri(it.atUri) },
-            artistUri = scrobbleView.artistUri?.let { ArtistUri(it.atUri) },
-            albumUri = scrobbleView.albumUri?.let { AlbumUri(it.atUri) },
+            trackUri = trackUri,
+            artistUri = artistUri,
+            albumUri = albumUri,
             createdAt = scrobbleView.createdAt,
         ),
     )

--- a/data/core/src/commonMain/kotlin/com/tunjid/heron/data/utilities/multipleEntitysaver/SaveRockskyTrackView.kt
+++ b/data/core/src/commonMain/kotlin/com/tunjid/heron/data/utilities/multipleEntitysaver/SaveRockskyTrackView.kt
@@ -15,6 +15,38 @@ internal fun MultipleEntitySaver.add(
     trackView: TrackView,
 ) {
     add(stubProfileEntity(Did(creatorId.id)))
+
+    val artistUri = trackView.artistUri?.let { ArtistUri(it.atUri) }
+    val albumArt = trackView.albumArt?.let { ImageUri(it.uri) }
+    // Album requires a non-null artistUri FK; if we don't have one, drop the
+    // track's albumUri rather than stubbing an album we can't satisfy.
+    val albumUri = trackView.albumUri
+        ?.takeIf { artistUri != null }
+        ?.let { AlbumUri(it.atUri) }
+
+    if (artistUri != null) {
+        add(
+            stubRockskyArtistEntity(
+                uri = artistUri,
+                creatorId = creatorId,
+                name = trackView.artist,
+            ),
+        )
+    }
+
+    if (albumUri != null && artistUri != null) {
+        add(
+            stubRockskyAlbumEntity(
+                uri = albumUri,
+                creatorId = creatorId,
+                artistUri = artistUri,
+                title = trackView.album ?: trackView.title,
+                artist = trackView.albumArtist ?: trackView.artist,
+                albumArt = albumArt,
+            ),
+        )
+    }
+
     add(
         RockskyTrackEntity(
             uri = TrackUri(trackView.uri.atUri),
@@ -24,12 +56,12 @@ internal fun MultipleEntitySaver.add(
             artist = trackView.artist,
             albumArtist = trackView.albumArtist,
             album = trackView.album,
-            albumArt = trackView.albumArt?.let { ImageUri(it.uri) },
+            albumArt = albumArt,
             trackNumber = trackView.trackNumber?.toInt(),
             discNumber = trackView.discNumber?.toInt(),
             duration = trackView.duration,
-            albumUri = trackView.albumUri?.let { AlbumUri(it.atUri) },
-            artistUri = trackView.artistUri?.let { ArtistUri(it.atUri) },
+            albumUri = albumUri,
+            artistUri = artistUri,
             createdAt = trackView.createdAt,
             playCount = trackView.playCount,
             uniqueListeners = trackView.uniqueListeners,

--- a/data/core/src/commonMain/kotlin/com/tunjid/heron/data/utilities/multipleEntitysaver/StubRockskyEntities.kt
+++ b/data/core/src/commonMain/kotlin/com/tunjid/heron/data/utilities/multipleEntitysaver/StubRockskyEntities.kt
@@ -1,0 +1,79 @@
+package com.tunjid.heron.data.utilities.multipleEntitysaver
+
+import com.tunjid.heron.data.core.types.AlbumId
+import com.tunjid.heron.data.core.types.AlbumUri
+import com.tunjid.heron.data.core.types.ArtistId
+import com.tunjid.heron.data.core.types.ArtistUri
+import com.tunjid.heron.data.core.types.ImageUri
+import com.tunjid.heron.data.core.types.ProfileId
+import com.tunjid.heron.data.core.types.TrackId
+import com.tunjid.heron.data.core.types.TrackUri
+import com.tunjid.heron.data.database.entities.RockskyAlbumEntity
+import com.tunjid.heron.data.database.entities.RockskyArtistEntity
+import com.tunjid.heron.data.database.entities.RockskyTrackEntity
+
+internal fun stubRockskyArtistEntity(
+    uri: ArtistUri,
+    creatorId: ProfileId,
+    name: String,
+) = RockskyArtistEntity(
+    uri = uri,
+    cid = ArtistId(uri.uri),
+    creatorId = creatorId,
+    name = name,
+    picture = null,
+    playCount = null,
+    uniqueListeners = null,
+    tags = null,
+)
+
+internal fun stubRockskyAlbumEntity(
+    uri: AlbumUri,
+    creatorId: ProfileId,
+    artistUri: ArtistUri,
+    title: String,
+    artist: String,
+    albumArt: ImageUri?,
+) = RockskyAlbumEntity(
+    uri = uri,
+    cid = AlbumId(uri.uri),
+    creatorId = creatorId,
+    title = title,
+    artist = artist,
+    releaseDate = null,
+    year = null,
+    albumArt = albumArt,
+    artistUri = artistUri,
+    playCount = null,
+    uniqueListeners = null,
+)
+
+internal fun stubRockskyTrackEntity(
+    uri: TrackUri,
+    cid: TrackId,
+    creatorId: ProfileId,
+    title: String,
+    artist: String,
+    albumArtist: String?,
+    album: String?,
+    albumArt: ImageUri?,
+    albumUri: AlbumUri?,
+    artistUri: ArtistUri?,
+) = RockskyTrackEntity(
+    uri = uri,
+    cid = cid,
+    creatorId = creatorId,
+    title = title,
+    artist = artist,
+    albumArtist = albumArtist,
+    album = album,
+    albumArt = albumArt,
+    trackNumber = null,
+    discNumber = null,
+    duration = null,
+    albumUri = albumUri,
+    artistUri = artistUri,
+    createdAt = null,
+    playCount = null,
+    uniqueListeners = null,
+)

--- a/data/database/src/commonMain/kotlin/com/tunjid/heron/data/database/daos/RockskyDao.kt
+++ b/data/database/src/commonMain/kotlin/com/tunjid/heron/data/database/daos/RockskyDao.kt
@@ -1,6 +1,8 @@
 package com.tunjid.heron.data.database.daos
 
 import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Transaction
 import androidx.room.Upsert
@@ -38,11 +40,71 @@ interface RockskyDao {
         entities: List<RockskyScrobbleEntity>,
     )
 
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertOrIgnoreArtists(
+        entities: List<RockskyArtistEntity>,
+    ): List<Long>
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertOrIgnoreAlbums(
+        entities: List<RockskyAlbumEntity>,
+    ): List<Long>
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertOrIgnoreTracks(
+        entities: List<RockskyTrackEntity>,
+    ): List<Long>
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertOrIgnoreScrobbles(
+        entities: List<RockskyScrobbleEntity>,
+    ): List<Long>
+
+    @Transaction
+    suspend fun insertOrPartiallyUpdateArtists(
+        entities: List<RockskyArtistEntity>,
+    ) = partialUpsert(
+        items = entities,
+        partialMapper = { it },
+        insertEntities = ::insertOrIgnoreArtists,
+        updatePartials = ::upsertArtists,
+    )
+
+    @Transaction
+    suspend fun insertOrPartiallyUpdateAlbums(
+        entities: List<RockskyAlbumEntity>,
+    ) = partialUpsert(
+        items = entities,
+        partialMapper = { it },
+        insertEntities = ::insertOrIgnoreAlbums,
+        updatePartials = ::upsertAlbums,
+    )
+
+    @Transaction
+    suspend fun insertOrPartiallyUpdateTracks(
+        entities: List<RockskyTrackEntity>,
+    ) = partialUpsert(
+        items = entities,
+        partialMapper = { it },
+        insertEntities = ::insertOrIgnoreTracks,
+        updatePartials = ::upsertTracks,
+    )
+
+    @Transaction
+    suspend fun insertOrPartiallyUpdateScrobbles(
+        entities: List<RockskyScrobbleEntity>,
+    ) = partialUpsert(
+        items = entities,
+        partialMapper = { it },
+        insertEntities = ::insertOrIgnoreScrobbles,
+        updatePartials = ::upsertScrobbles,
+    )
+
     @Query(
         """
     SELECT * FROM rockskyAlbums
     WHERE creatorId = :profileId
-    ORDER BY title ASC
+    ORDER BY COALESCE(playCount, 0) DESC, title ASC
     LIMIT :limit OFFSET :offset
     """,
     )
@@ -56,7 +118,7 @@ interface RockskyDao {
         """
     SELECT * FROM rockskyTracks
     WHERE creatorId = :profileId
-    ORDER BY title ASC
+    ORDER BY COALESCE(playCount, 0) DESC, title ASC
     LIMIT :limit OFFSET :offset
     """,
     )
@@ -70,7 +132,7 @@ interface RockskyDao {
         """
     SELECT * FROM rockskyArtists
     WHERE creatorId = :profileId
-    ORDER BY name ASC
+    ORDER BY COALESCE(playCount, 0) DESC, name ASC
     LIMIT :limit OFFSET :offset
     """,
     )


### PR DESCRIPTION
@joelmuraguri a few things about the rocksky integration:

* When saving entities that use foreign keys, you need to make sure the foreign keys are saved first.
* Entities with foreign keys should also stub its foreign keys in case it doesn't exist in the db yet.
* We also need to make sure the order the db is queried matches the order from the network response.