### PR TITLE
Auto focus search bar on screen entry and nav selection

### DIFF
--- a/feature/search/src/commonMain/kotlin/com/tunjid/heron/search/di/Bindings.kt
+++ b/feature/search/src/commonMain/kotlin/com/tunjid/heron/search/di/Bindings.kt
@@ -21,7 +21,10 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.unit.round
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -143,6 +146,12 @@ class SearchBindings(
             val state = stateHolder.produceStateWithLifecycle()
             val paneScaffoldState = rememberPaneScaffoldState()
 
+            val searchFocusRequester = remember { FocusRequester() }
+
+            LaunchedEffect(Unit) {
+                searchFocusRequester.requestFocus()
+            }
+
             val topAppBarNestedScrollConnection =
                 topAppBarNestedScrollConnection()
 
@@ -173,6 +182,7 @@ class SearchBindings(
                         title = {
                             SearchBar(
                                 searchQuery = state.currentQuery,
+                                focusRequester = searchFocusRequester,
                                 onQueryChanged = { query ->
                                     stateHolder.accept(
                                         Action.Search.OnSearchQueryChanged(query),
@@ -225,6 +235,10 @@ class SearchBindings(
                             .offset {
                                 bottomNavigationNestedScrollConnection.offset.round()
                             },
+                        onNavItemReselected = {
+                            searchFocusRequester.requestFocus()
+                            true
+                        },
                     )
                 },
                 navigationRail = {

--- a/feature/search/src/commonMain/kotlin/com/tunjid/heron/search/di/Bindings.kt
+++ b/feature/search/src/commonMain/kotlin/com/tunjid/heron/search/di/Bindings.kt
@@ -149,7 +149,7 @@ class SearchBindings(
             val searchFocusRequester = remember { FocusRequester() }
 
             LaunchedEffect(Unit) {
-                searchFocusRequester.requestFocus()
+                if (state.isQueryEditable) searchFocusRequester.requestFocus()
             }
 
             val topAppBarNestedScrollConnection =
@@ -236,7 +236,7 @@ class SearchBindings(
                                 bottomNavigationNestedScrollConnection.offset.round()
                             },
                         onNavItemReselected = {
-                            searchFocusRequester.requestFocus()
+                            if (state.isQueryEditable) searchFocusRequester.requestFocus()
                             true
                         },
                     )

--- a/feature/search/src/commonMain/kotlin/com/tunjid/heron/search/di/Bindings.kt
+++ b/feature/search/src/commonMain/kotlin/com/tunjid/heron/search/di/Bindings.kt
@@ -149,7 +149,7 @@ class SearchBindings(
             val searchFocusRequester = remember { FocusRequester() }
 
             LaunchedEffect(Unit) {
-                if (state.isQueryEditable) searchFocusRequester.requestFocus()
+                searchFocusRequester.requestFocus()
             }
 
             val topAppBarNestedScrollConnection =
@@ -236,7 +236,7 @@ class SearchBindings(
                                 bottomNavigationNestedScrollConnection.offset.round()
                             },
                         onNavItemReselected = {
-                            if (state.isQueryEditable) searchFocusRequester.requestFocus()
+                            searchFocusRequester.requestFocus()
                             true
                         },
                     )


### PR DESCRIPTION
Resolves #1314. Users navigating to the Search screen or re-clicking
the Search navigation item expect the search input field to be immediately focused with the keyboard open.

## Changes

- Hoisted `FocusRequester` within `SearchBindings`.
- Added a `LaunchedEffect` to automatically request focus on the initial screen composition.
- Bound the hoisted `FocusRequester` to `PaneNavigationBar` 
 `(onNavItemReselected)` to gracefully restore focus whenever the search nav icon is tapped while already on the screen