### PR TITLE
Expand home tabs on Heron logo click

### DIFF
--- a/feature/home/src/commonMain/kotlin/com/tunjid/heron/home/di/Bindings.kt
+++ b/feature/home/src/commonMain/kotlin/com/tunjid/heron/home/di/Bindings.kt
@@ -203,6 +203,15 @@ class HomeBindings(
                                 ),
                             )
                         },
+                        onLogoClicked = {
+                            val nextLayout = if (state.tabLayout is TabLayout.Expanded) {
+                                TabLayout.Collapsed.All
+                            } else {
+                                TabLayout.Expanded
+                            }
+
+                            stateHolder.accept(Action.SetTabLayout(layout = nextLayout))
+                        },
                     )
                 },
                 snackBarHost = {

--- a/feature/home/src/commonMain/kotlin/com/tunjid/heron/home/di/Bindings.kt
+++ b/feature/home/src/commonMain/kotlin/com/tunjid/heron/home/di/Bindings.kt
@@ -204,13 +204,15 @@ class HomeBindings(
                             )
                         },
                         onLogoClicked = {
-                            val nextLayout = if (state.tabLayout is TabLayout.Expanded) {
-                                TabLayout.Collapsed.All
-                            } else {
-                                TabLayout.Expanded
-                            }
-
-                            stateHolder.accept(Action.SetTabLayout(layout = nextLayout))
+                            stateHolder.accept(
+                                Action.SetTabLayout(
+                                    layout = if (state.tabLayout is TabLayout.Expanded) {
+                                        TabLayout.Collapsed.All
+                                    } else {
+                                        TabLayout.Expanded
+                                    },
+                                ),
+                            )
                         },
                     )
                 },

--- a/scaffold/src/commonMain/kotlin/com/tunjid/heron/scaffold/scaffold/PaneTopAppBar.kt
+++ b/scaffold/src/commonMain/kotlin/com/tunjid/heron/scaffold/scaffold/PaneTopAppBar.kt
@@ -68,6 +68,7 @@ fun PaneScaffoldState.RootDestinationTopAppBar(
     actions: (@Composable RowScope.() -> Unit)? = null,
     transparencyFactor: () -> Float = { 0f },
     onSignedInProfileClicked: (Profile, String) -> Unit,
+    onLogoClicked: (() -> Unit)? = null,
 ) {
     val isLive = signedInProfile?.status?.isLive == true
     ClickPassThroughToolbar(
@@ -94,7 +95,14 @@ fun PaneScaffoldState.RootDestinationTopAppBar(
             AppLogo(
                 modifier = Modifier
                     .padding(8.dp)
-                    .size(UiTokens.avatarSize),
+                    .size(UiTokens.avatarSize)
+                    .let { baseModifier ->
+                        if (onLogoClicked != null) {
+                            baseModifier.shapedClickable(CircleShape, onClick = onLogoClicked)
+                        } else {
+                            baseModifier
+                        }
+                    },
                 presentation = LogoPresentation.Destination.Root(
                     blurProgress = transparencyFactor,
                 ),

--- a/scaffold/src/commonMain/kotlin/com/tunjid/heron/scaffold/scaffold/PaneTopAppBar.kt
+++ b/scaffold/src/commonMain/kotlin/com/tunjid/heron/scaffold/scaffold/PaneTopAppBar.kt
@@ -96,13 +96,13 @@ fun PaneScaffoldState.RootDestinationTopAppBar(
                 modifier = Modifier
                     .padding(8.dp)
                     .size(UiTokens.avatarSize)
-                    .let { baseModifier ->
+                    .then(
                         if (onLogoClicked != null) {
-                            baseModifier.shapedClickable(CircleShape, onClick = onLogoClicked)
+                            Modifier.shapedClickable(CircleShape, onClick = onLogoClicked)
                         } else {
-                            baseModifier
-                        }
-                    },
+                            Modifier
+                        },
+                    ),
                 presentation = LogoPresentation.Destination.Root(
                     blurProgress = transparencyFactor,
                 ),


### PR DESCRIPTION
- This PR addresses #1315 by allowing users to expand the Home Tabs when tapping the Heron logo on the home screen toolbar.

- As requested in the task implementation notes, `RootDestinationTopAppBar` now accepts an optional click listener for the logo without breaking external screens that rely on its default static behavior.

## Changes
- **`RootDestinationTopAppBar`**: Added an optional, nullable `onLogoClicked: (() -> Unit)? = null` lambda. When populated, a `shapedClickable(CircleShape)` modifier is dynamically chained onto the `AppLogo` layout.
- **`HomeBindings`**: Bound the new `onLogoClicked` callback within the home scaffold top bar declaration to trigger `Action.SetTabLayout(TabLayout.Expanded)` (or toggle states) using the screen's `stateHolder`.

## Related Issues
Closes #1315
See also #1311

## Testing Done
- Verified that tapping the logo successfully toggles/expands the tab layout on the Home Screen.
- Verified that the ripple shape perfectly matches the circular `AppLogo` design boundaries.
- Checked other screens utilizing `RootDestinationTopAppBar` to ensure no regression or unwanted interaction behavior occurred where the lambda isn't supplied.