### PR TITLE
Show "You:" prefix for last message in conversation list 

### DIFF
--- a/feature/messages/src/commonMain/composeResources/values/strings.xml
+++ b/feature/messages/src/commonMain/composeResources/values/strings.xml
@@ -21,4 +21,5 @@
     <string name="error_conversation_not_found">Could not find conversation with %1$s. Please try again later.</string>
     <string name="error_cannot_be_messaged">Can't be messaged</string>
     <string name="title">Messages</string>
+    <string name="you_sent_prefix">You: </string>
 </resources>

--- a/feature/messages/src/commonMain/composeResources/values/strings.xml
+++ b/feature/messages/src/commonMain/composeResources/values/strings.xml
@@ -21,5 +21,5 @@
     <string name="error_conversation_not_found">Could not find conversation with %1$s. Please try again later.</string>
     <string name="error_cannot_be_messaged">Can't be messaged</string>
     <string name="title">Messages</string>
-    <string name="you_sent_prefix">You: </string>
+    <string name="you_sent_summary">You: %1$s</string>
 </resources>

--- a/feature/messages/src/commonMain/kotlin/com/tunjid/heron/messages/MessagesScreen.kt
+++ b/feature/messages/src/commonMain/kotlin/com/tunjid/heron/messages/MessagesScreen.kt
@@ -64,6 +64,7 @@ import com.tunjid.tiler.compose.PivotedTilingEffect
 import com.tunjid.treenav.compose.UpdatedMovableStickySharedElementOf
 import heron.feature.messages.generated.resources.Res
 import heron.feature.messages.generated.resources.sender_reacted
+import heron.feature.messages.generated.resources.you_sent_prefix
 import kotlin.time.Instant
 import org.jetbrains.compose.resources.stringResource
 
@@ -186,7 +187,7 @@ fun Conversation(
         ConversationDetails(
             participants = participants,
             signedInProfileId = signedInProfileId,
-            conversationSummary = conversation.summary(),
+            conversationSummary = conversation.summary(signedInProfileId = signedInProfileId),
         )
     }
 }
@@ -266,15 +267,20 @@ private fun ConversationDetails(
 }
 
 @Composable
-private fun Conversation.summary(): String {
+private fun Conversation.summary(signedInProfileId: ProfileId?): String {
     val lastMessage = lastMessage
     val lastMessageReactedTo = lastMessageReactedTo?.takeIf { it.reactions.isNotEmpty() }
 
     return when {
-        lastMessageReactedTo == null -> lastMessage?.text ?: ""
-        // Invalid state.
-        // A reaction should not be able to occur if there's no message to react to.
+        lastMessageReactedTo == null -> lastMessage?.let { message ->
+            val prefix = if (message.sender.did == signedInProfileId) {
+                stringResource(Res.string.you_sent_prefix)
+            } else ""
+            "$prefix${message.text}"
+        } ?: ""
+
         lastMessage == null -> ""
+
         else -> maxOf(
             a = lastMessage,
             b = lastMessageReactedTo,
@@ -283,7 +289,6 @@ private fun Conversation.summary(): String {
                 val lastMessageReactedToAt = b.reactions.maxOfOrNull(
                     Message.Reaction::createdAt,
                 ) ?: Instant.DISTANT_PAST
-
                 lastMessageSent.compareTo(lastMessageReactedToAt)
             },
         ).let { mostRecent ->
@@ -298,7 +303,12 @@ private fun Conversation.summary(): String {
                         mostRecent.text,
                     )
                 }
-                lastMessage -> mostRecent.text
+                lastMessage -> {
+                    val prefix = if (mostRecent.sender.did == signedInProfileId) {
+                        stringResource(Res.string.you_sent_prefix)
+                    } else ""
+                    "$prefix${mostRecent.text}"
+                }
                 else -> ""
             }
         }

--- a/feature/messages/src/commonMain/kotlin/com/tunjid/heron/messages/MessagesScreen.kt
+++ b/feature/messages/src/commonMain/kotlin/com/tunjid/heron/messages/MessagesScreen.kt
@@ -64,7 +64,7 @@ import com.tunjid.tiler.compose.PivotedTilingEffect
 import com.tunjid.treenav.compose.UpdatedMovableStickySharedElementOf
 import heron.feature.messages.generated.resources.Res
 import heron.feature.messages.generated.resources.sender_reacted
-import heron.feature.messages.generated.resources.you_sent_prefix
+import heron.feature.messages.generated.resources.you_sent_summary
 import kotlin.time.Instant
 import org.jetbrains.compose.resources.stringResource
 
@@ -272,11 +272,10 @@ private fun Conversation.summary(signedInProfileId: ProfileId?): String {
     val lastMessageReactedTo = lastMessageReactedTo?.takeIf { it.reactions.isNotEmpty() }
 
     return when {
-        lastMessageReactedTo == null -> lastMessage?.let { message ->
-            val prefix = if (message.sender.did == signedInProfileId) {
-                stringResource(Res.string.you_sent_prefix)
-            } else ""
-            "$prefix${message.text}"
+        lastMessageReactedTo == null -> lastMessage?.let {
+            if (it.sender.did == signedInProfileId) {
+                stringResource(Res.string.you_sent_summary, it.text)
+            } else it.text
         } ?: ""
 
         lastMessage == null -> ""
@@ -304,10 +303,9 @@ private fun Conversation.summary(signedInProfileId: ProfileId?): String {
                     )
                 }
                 lastMessage -> {
-                    val prefix = if (mostRecent.sender.did == signedInProfileId) {
-                        stringResource(Res.string.you_sent_prefix)
-                    } else ""
-                    "$prefix${mostRecent.text}"
+                    if (mostRecent.sender.did == signedInProfileId) {
+                        stringResource(Res.string.you_sent_summary, mostRecent.text)
+                    } else mostRecent.text
                 }
                 else -> ""
             }


### PR DESCRIPTION
Closes #1317

What changed:
- Updated `Conversation.summary()` to accept `signedInProfileId` and compare against message.`sender.did`
- When the signed-in user sent the last message, the summary now prefixes with **You:** 
- Added `you_sent_prefix` string resource
- Threaded `signedInProfileId` from the `Conversation` composable down into the `summary()` call