### PR TITLE
Show alt text in media overlay on GalleryScreen

### DIFF
--- a/feature/gallery/src/commonMain/kotlin/com/tunjid/heron/gallery/GalleryScreen.kt
+++ b/feature/gallery/src/commonMain/kotlin/com/tunjid/heron/gallery/GalleryScreen.kt
@@ -510,6 +510,7 @@ private fun HorizontalItems(
                             .weight(1f),
                         signedInProfileId = signedInProfileId,
                         item = item,
+                        media = media,
                         paneScaffoldState = paneScaffoldState,
                         actions = actions,
                     )

--- a/feature/gallery/src/commonMain/kotlin/com/tunjid/heron/gallery/ui/Media.kt
+++ b/feature/gallery/src/commonMain/kotlin/com/tunjid/heron/gallery/ui/Media.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
@@ -275,7 +276,10 @@ internal fun MediaCreatorAndDescription(
         )
         val altText = (media as? GalleryItem.Media.Photo)?.image?.alt
         if (!altText.isNullOrBlank()) {
-            ElevatedCard {
+            ElevatedCard(
+                modifier = Modifier
+                    .fillMaxWidth(),
+            ) {
                 Text(
                     modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
                     text = altText,

--- a/feature/gallery/src/commonMain/kotlin/com/tunjid/heron/gallery/ui/Media.kt
+++ b/feature/gallery/src/commonMain/kotlin/com/tunjid/heron/gallery/ui/Media.kt
@@ -33,8 +33,10 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.VolumeOff
 import androidx.compose.material.icons.automirrored.rounded.VolumeUp
 import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -45,6 +47,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import com.tunjid.heron.data.core.models.LinkTarget
@@ -212,6 +215,7 @@ internal fun MediaCreatorAndDescription(
     modifier: Modifier,
     signedInProfileId: ProfileId?,
     item: GalleryItem,
+    media: GalleryItem.Media,
     paneScaffoldState: PaneScaffoldState,
     actions: (Action) -> Unit,
 ) {
@@ -269,6 +273,19 @@ internal fun MediaCreatorAndDescription(
                 )
             },
         )
+        val altText = (media as? GalleryItem.Media.Photo)?.image?.alt
+        if (!altText.isNullOrBlank()) {
+            ElevatedCard {
+                Text(
+                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+                    text = altText,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 3,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Closes #1316

## What changed
- Added a `media` parameter to `MediaCreatorAndDescription` to receive
  the currently visible page's media item
- Renders alt text in an `ElevatedCard` below the post caption when the
  current photo has non-blank alt text
- Videos are unaffected as they carry no alt text in the model

## Testing
Open any post with images in the Gallery screen. For images posted with
alt text, an elevated card will appear below the caption in the media
overlay. Images without alt text are unaffected.