### PR TITLE
Migrate EmbeddableRecordOptionsSheetState to ViewModel-backed state

### DIFF
--- a/feature/feed/src/commonMain/kotlin/com/tunjid/heron/feed/di/Bindings.kt
+++ b/feature/feed/src/commonMain/kotlin/com/tunjid/heron/feed/di/Bindings.kt
@@ -214,19 +214,6 @@ class FeedBindings(
                         state.signedInProfileId == timeline.feedGenerator.creator.did
                     if (isEditable) editFeedText else null
                 },
-                onEditClicked = onEditClicked@{
-                    stateHolder.accept(
-                        Action.Navigate.To(
-                            grazeEditorDestination(
-                                feedGenerator = state.timelineState
-                                    ?.timeline
-                                    ?.withFeedTimelineOrNull(Timeline.Home.Feed::feedGenerator)
-                                    ?: return@onEditClicked,
-                                sharedElementPrefix = state.sharedElementPrefix,
-                            ),
-                        ),
-                    )
-                },
                 onShareInConversationClicked = { recordUri, conversation ->
                     stateHolder.accept(
                         Action.Navigate.To(
@@ -236,6 +223,19 @@ class FeedBindings(
                                 sharedElementPrefix = conversation.id.id,
                                 sharedUri = recordUri.asGenericUri(),
                                 referringRouteOption = NavigationAction.ReferringRouteOption.Current,
+                            ),
+                        ),
+                    )
+                },
+                onEditClicked = onEditClicked@{
+                    stateHolder.accept(
+                        Action.Navigate.To(
+                            grazeEditorDestination(
+                                feedGenerator = state.timelineState
+                                    ?.timeline
+                                    ?.withFeedTimelineOrNull(Timeline.Home.Feed::feedGenerator)
+                                    ?: return@onEditClicked,
+                                sharedElementPrefix = state.sharedElementPrefix,
                             ),
                         ),
                     )

--- a/feature/feed/src/commonMain/kotlin/com/tunjid/heron/feed/di/Bindings.kt
+++ b/feature/feed/src/commonMain/kotlin/com/tunjid/heron/feed/di/Bindings.kt
@@ -60,12 +60,13 @@ import com.tunjid.heron.scaffold.scaffold.PoppableDestinationTopAppBar
 import com.tunjid.heron.scaffold.scaffold.SecondaryPaneCloseBackHandler
 import com.tunjid.heron.scaffold.scaffold.isFabExpanded
 import com.tunjid.heron.scaffold.scaffold.predictiveBackPlacement
+import com.tunjid.heron.scaffold.scaffold.rememberEmbeddableRecordOptionsSheetState
 import com.tunjid.heron.scaffold.scaffold.rememberPaneScaffoldState
 import com.tunjid.heron.tiling.TilingState
 import com.tunjid.heron.timeline.state.TimelineState
-import com.tunjid.heron.timeline.ui.EmbeddableRecordOptionsSheetState.Companion.rememberUpdatedEmbeddableRecordOptionsState
 import com.tunjid.heron.timeline.ui.ShareRecordButton
 import com.tunjid.heron.timeline.ui.feed.FeedGeneratorStatus
+import com.tunjid.heron.timeline.ui.sheets.embedrecordoptions.EmbeddableRecordOptionsSheetState.Companion.rememberUpdatedEmbeddableRecordOptionsState
 import com.tunjid.heron.timeline.utilities.TimelineTitle
 import com.tunjid.heron.ui.coroutines.viewModelCoroutineScope
 import com.tunjid.heron.ui.topAppBarNestedScrollConnection
@@ -207,26 +208,11 @@ class FeedBindings(
             val paneScaffoldState = rememberPaneScaffoldState()
 
             val editFeedText = stringResource(Res.string.edit_feed)
-            val recordOptionsSheetState = rememberUpdatedEmbeddableRecordOptionsState(
-                signedInProfileId = state.signedInProfileId,
-                recentConversations = emptyList(),
+            val recordOptionsSheetState = paneScaffoldState.rememberEmbeddableRecordOptionsSheetState(
                 editTitle = state.timelineState?.timeline?.withFeedTimelineOrNull { timeline ->
                     val isEditable = timeline.feedGenerator.isGrazeFeed &&
                         state.signedInProfileId == timeline.feedGenerator.creator.did
                     if (isEditable) editFeedText else null
-                },
-                onShareInConversationClicked = { recordUri, conversation ->
-                    stateHolder.accept(
-                        Action.Navigate.To(
-                            conversationDestination(
-                                id = conversation.id,
-                                members = conversation.members,
-                                sharedElementPrefix = conversation.id.id,
-                                sharedUri = recordUri.asGenericUri(),
-                                referringRouteOption = NavigationAction.ReferringRouteOption.Current,
-                            ),
-                        ),
-                    )
                 },
                 onEditClicked = onEditClicked@{
                     stateHolder.accept(
@@ -241,12 +227,23 @@ class FeedBindings(
                         ),
                     )
                 },
+                onShareInConversationClicked = { recordUri, conversation ->
+                    stateHolder.accept(
+                        Action.Navigate.To(
+                            conversationDestination(
+                                id = conversation.id,
+                                members = conversation.members,
+                                sharedElementPrefix = conversation.id.id,
+                                sharedUri = recordUri.asGenericUri(),
+                                referringRouteOption = NavigationAction.ReferringRouteOption.Current,
+                            ),
+                        ),
+                    )
+                },
                 onShareInPostClicked = { recordUri ->
                     stateHolder.accept(
                         Action.Navigate.To(
-                            composePostDestination(
-                                sharedUri = recordUri.asGenericUri(),
-                            ),
+                            composePostDestination(sharedUri = recordUri.asGenericUri()),
                         ),
                     )
                 },

--- a/feature/list/src/commonMain/kotlin/com/tunjid/heron/list/di/Bindings.kt
+++ b/feature/list/src/commonMain/kotlin/com/tunjid/heron/list/di/Bindings.kt
@@ -65,9 +65,9 @@ import com.tunjid.heron.scaffold.scaffold.PoppableDestinationTopAppBar
 import com.tunjid.heron.scaffold.scaffold.SecondaryPaneCloseBackHandler
 import com.tunjid.heron.scaffold.scaffold.isFabExpanded
 import com.tunjid.heron.scaffold.scaffold.predictiveBackPlacement
+import com.tunjid.heron.scaffold.scaffold.rememberEmbeddableRecordOptionsSheetState
 import com.tunjid.heron.scaffold.scaffold.rememberPaneScaffoldState
 import com.tunjid.heron.timeline.state.TimelineState
-import com.tunjid.heron.timeline.ui.EmbeddableRecordOptionsSheetState.Companion.rememberUpdatedEmbeddableRecordOptionsState
 import com.tunjid.heron.timeline.ui.ShareRecordButton
 import com.tunjid.heron.timeline.ui.list.FeedListStatus
 import com.tunjid.heron.timeline.ui.sheets.SelectTextSheetState.Companion.rememberSelectProfileIdState
@@ -296,9 +296,7 @@ class ListBindings(
                     stateHolder.accept(Action.SnackbarDismissed(it))
                 },
                 topBar = {
-                    val recordOptionsSheetState = rememberUpdatedEmbeddableRecordOptionsState(
-                        signedInProfileId = state.signedInProfileId,
-                        recentConversations = emptyList(),
+                    val recordOptionsSheetState = rememberEmbeddableRecordOptionsSheetState(
                         editTitle = null,
                         onEditClicked = {},
                         onShareInConversationClicked = { recordUri, conversation ->

--- a/scaffold/src/commonMain/kotlin/com/tunjid/heron/scaffold/scaffold/PaneSheets.kt
+++ b/scaffold/src/commonMain/kotlin/com/tunjid/heron/scaffold/scaffold/PaneSheets.kt
@@ -1,13 +1,14 @@
 package com.tunjid.heron.scaffold.scaffold
 
 import androidx.compose.runtime.Composable
+import com.tunjid.heron.data.core.models.Conversation
 import com.tunjid.heron.data.core.models.Post
 import com.tunjid.heron.data.core.models.PostInteractionSettingsPreference
-import com.tunjid.heron.data.core.models.ThreadGate
+import com.tunjid.heron.data.core.types.EmbeddableRecordUri
+import com.tunjid.heron.timeline.ui.sheets.embedrecordoptions.EmbeddableRecordOptionsSheetState
 import com.tunjid.heron.timeline.ui.sheets.mutedwords.MutedWordsSheetState
 import com.tunjid.heron.timeline.ui.sheets.postoptions.PostOption
 import com.tunjid.heron.timeline.ui.sheets.postoptions.PostOptionsSheetState
-import com.tunjid.heron.timeline.ui.sheets.threadgate.Mode
 import com.tunjid.heron.timeline.ui.sheets.threadgate.ThreadGateSheetState
 
 @Composable
@@ -41,4 +42,19 @@ fun PaneScaffoldState.rememberPreferenceThreadGateSheetState(
     ThreadGateSheetState.rememberUpdatedThreadGateSheetState(
         initializer = appState.sheetsViewModelInitializers.threadGateViewModelInitializer,
         onDefaultThreadGateUpdated = onDefaultThreadGateUpdated,
+    )
+
+@Composable
+fun PaneScaffoldState.rememberEmbeddableRecordOptionsSheetState(
+    editTitle: String?,
+    onEditClicked: (EmbeddableRecordUri) -> Unit,
+    onShareInConversationClicked: (EmbeddableRecordUri, Conversation) -> Unit,
+    onShareInPostClicked: (EmbeddableRecordUri) -> Unit,
+): EmbeddableRecordOptionsSheetState =
+    EmbeddableRecordOptionsSheetState.rememberUpdatedEmbeddableRecordOptionsState(
+        initializer = appState.sheetsViewModelInitializers.embeddableRecordOptionsViewModelInitializer,
+        editTitle = editTitle,
+        onEditClicked = onEditClicked,
+        onShareInConversationClicked = onShareInConversationClicked,
+        onShareInPostClicked = onShareInPostClicked,
     )

--- a/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/di/Bindings.kt
+++ b/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/di/Bindings.kt
@@ -17,6 +17,7 @@
 package com.tunjid.heron.timeline.di
 
 import com.tunjid.heron.data.di.DataBindings
+import com.tunjid.heron.timeline.ui.sheets.embedrecordoptions.EmbeddableRecordOptionsViewModelInitializer
 import com.tunjid.heron.timeline.ui.sheets.mutedwords.MutedWordsViewModelInitializer
 import com.tunjid.heron.timeline.ui.sheets.postoptions.PostOptionsViewModelInitializer
 import com.tunjid.heron.timeline.ui.sheets.threadgate.ThreadGateViewModelInitializer
@@ -34,9 +35,11 @@ class SheetBindings(
         mutedWordsViewModelInitializer: MutedWordsViewModelInitializer,
         postOptionsViewModelInitializer: PostOptionsViewModelInitializer,
         threadGateViewModelInitializer: ThreadGateViewModelInitializer,
+        embeddableRecordOptionsViewModelInitializer: EmbeddableRecordOptionsViewModelInitializer,
     ): SheetsViewModelInitializers = SheetsViewModelInitializers(
         mutedWordsViewModelInitializer = mutedWordsViewModelInitializer,
         postOptionsViewModelInitializer = postOptionsViewModelInitializer,
         threadGateViewModelInitializer = threadGateViewModelInitializer,
+        embeddableRecordOptionsViewModelInitializer = embeddableRecordOptionsViewModelInitializer,
     )
 }

--- a/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/ui/sheets/embedrecordoptions/EmbeddableRecordOptionsSheetState.kt
+++ b/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/ui/sheets/embedrecordoptions/EmbeddableRecordOptionsSheetState.kt
@@ -14,7 +14,7 @@
  *    limitations under the License.
  */
 
-package com.tunjid.heron.timeline.ui
+package com.tunjid.heron.timeline.ui.sheets.embedrecordoptions
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -44,20 +44,18 @@ import com.tunjid.heron.ui.sheets.BottomSheetScope
 import com.tunjid.heron.ui.sheets.BottomSheetScope.Companion.ModalBottomSheet
 import com.tunjid.heron.ui.sheets.BottomSheetScope.Companion.rememberBottomSheetState
 import com.tunjid.heron.ui.sheets.BottomSheetState
+import com.tunjid.mutator.compose.produceState
 
 @Stable
-class EmbeddableRecordOptionsSheetState private constructor(
-    signedInProfileId: ProfileId?,
-    recentConversations: List<Conversation>,
+class EmbeddableRecordOptionsSheetState(
     scope: BottomSheetScope,
+    internal val viewModel: EmbeddableRecordOptionsViewModel,
 ) : BottomSheetState(scope) {
-    internal var signedInProfileId by mutableStateOf(signedInProfileId)
 
-    internal var recentConversations by mutableStateOf(recentConversations)
+    var currentRecordUri: EmbeddableRecordUri? by mutableStateOf(null)
+        internal set
 
-    internal var currentRecordUri: EmbeddableRecordUri? by mutableStateOf(null)
-
-    internal val isSignedIn get() = signedInProfileId != null
+    internal var editTitle: String? by mutableStateOf(null)
 
     override fun onHidden() {
         currentRecordUri = null
@@ -68,30 +66,24 @@ class EmbeddableRecordOptionsSheetState private constructor(
         show()
     }
 
-    companion object Companion {
+    companion object {
         @Composable
         fun rememberUpdatedEmbeddableRecordOptionsState(
-            signedInProfileId: ProfileId?,
+            initializer: EmbeddableRecordOptionsViewModelInitializer,
             editTitle: String?,
-            recentConversations: List<Conversation>,
             onEditClicked: (EmbeddableRecordUri) -> Unit,
             onShareInConversationClicked: (EmbeddableRecordUri, Conversation) -> Unit,
             onShareInPostClicked: (EmbeddableRecordUri) -> Unit,
         ): EmbeddableRecordOptionsSheetState {
-            val state = rememberBottomSheetState {
-                EmbeddableRecordOptionsSheetState(
-                    signedInProfileId = signedInProfileId,
-                    recentConversations = recentConversations,
-                    scope = it,
-                )
-            }.also {
-                it.signedInProfileId = signedInProfileId
-                it.recentConversations = recentConversations
+            val state = rememberBottomSheetState(
+                viewModelInitializer = initializer::invoke,
+                block = ::EmbeddableRecordOptionsSheetState,
+            ).also {
+                it.editTitle = editTitle
             }
 
             EmbeddableRecordOptionsBottomSheet(
                 state = state,
-                editTitle = editTitle,
                 onEditClicked = onEditClicked,
                 onShareInConversationClicked = onShareInConversationClicked,
                 onShareInPostClicked = onShareInPostClicked,
@@ -105,42 +97,44 @@ class EmbeddableRecordOptionsSheetState private constructor(
 @Composable
 private fun EmbeddableRecordOptionsBottomSheet(
     state: EmbeddableRecordOptionsSheetState,
-    editTitle: String?,
     onEditClicked: (EmbeddableRecordUri) -> Unit,
     onShareInConversationClicked: (EmbeddableRecordUri, Conversation) -> Unit,
     onShareInPostClicked: (EmbeddableRecordUri) -> Unit,
 ) {
-    val signedInProfileId = state.signedInProfileId
+    state.ModalBottomSheet {
+        val embeddableState = state.viewModel.produceState()
 
-    if (signedInProfileId != null) state.ModalBottomSheet {
+        val editTitle = state.editTitle
+
         Column(
             modifier = Modifier.padding(horizontal = 16.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            SendDirectMessageCard(
-                signedInProfileId = signedInProfileId,
-                recentConversations = state.recentConversations,
-                onConversationClicked = { conversation ->
-                    state.currentRecordUri?.let { uri ->
-                        onShareInConversationClicked(uri, conversation)
-                    }
-                    state.hide()
-                },
-            )
+            val signedInProfileId = embeddableState.signedInProfileId
+            if (signedInProfileId != null) {
+                SendDirectMessageCard(
+                    signedInProfileId = signedInProfileId,
+                    recentConversations = embeddableState.recentConversations,
+                    onConversationClicked = { conversation ->
+                        state.currentRecordUri?.let { uri ->
+                            onShareInConversationClicked(uri, conversation)
+                        }
+                        state.hide()
+                    },
+                )
+            }
             if (editTitle != null) {
                 BottomSheetItemCard(
                     modifier = Modifier.fillMaxWidth(),
                     onClick = {
-                        state.currentRecordUri
-                            ?.let(onEditClicked)
+                        state.currentRecordUri?.let(onEditClicked)
                         state.hide()
                     },
                 ) {
                     BottomSheetItemCardRow(
-                        modifier = Modifier
-                            .semantics {
-                                contentDescription = editTitle
-                            },
+                        modifier = Modifier.semantics {
+                            contentDescription = editTitle
+                        },
                         icon = Icons.Rounded.Edit,
                         text = editTitle,
                     )
@@ -152,7 +146,6 @@ private fun EmbeddableRecordOptionsBottomSheet(
                 }
                 state.hide()
             }
-
             state.currentRecordUri?.let { uri ->
                 CopyToClipboardCard(uri.shareUri())
             }

--- a/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/ui/sheets/embedrecordoptions/EmbeddableRecordOptionsSheetState.kt
+++ b/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/ui/sheets/embedrecordoptions/EmbeddableRecordOptionsSheetState.kt
@@ -55,8 +55,6 @@ class EmbeddableRecordOptionsSheetState(
     var currentRecordUri: EmbeddableRecordUri? by mutableStateOf(null)
         internal set
 
-    internal var editTitle: String? by mutableStateOf(null)
-
     override fun onHidden() {
         currentRecordUri = null
     }
@@ -79,7 +77,7 @@ class EmbeddableRecordOptionsSheetState(
                 viewModelInitializer = initializer::invoke,
                 block = ::EmbeddableRecordOptionsSheetState,
             ).also {
-                it.editTitle = editTitle
+                it.viewModel.accept(EmbeddableRecordOptionsAction.SetEditTitle(editTitle))
             }
 
             EmbeddableRecordOptionsBottomSheet(
@@ -104,7 +102,7 @@ private fun EmbeddableRecordOptionsBottomSheet(
     state.ModalBottomSheet {
         val embeddableState = state.viewModel.produceState()
 
-        val editTitle = state.editTitle
+        val editTitle = embeddableState.editTitle
 
         Column(
             modifier = Modifier.padding(horizontal = 16.dp),

--- a/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/ui/sheets/embedrecordoptions/EmbeddableRecordOptionsStateHolder.kt
+++ b/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/ui/sheets/embedrecordoptions/EmbeddableRecordOptionsStateHolder.kt
@@ -11,6 +11,7 @@ import com.tunjid.heron.timeline.utilities.SheetWhileSubscribed
 import com.tunjid.heron.ui.coroutines.launchAndCollect
 import com.tunjid.mutator.coroutines.ActionSuspendingStateMutator
 import com.tunjid.mutator.coroutines.actionSuspendingStateMutator
+import com.tunjid.mutator.coroutines.launchMutationsIn
 import com.tunjid.snapshottable.SnapshotSpec
 import com.tunjid.snapshottable.Snapshottable
 import dev.zacsweers.metro.Assisted
@@ -40,7 +41,7 @@ class EmbeddableRecordOptionsViewModel(
     EmbeddableRecordOptionsStateHolder by scope.actionSuspendingStateMutator(
         state = EmbeddableRecordOptionsState.Immutable().toSnapshotMutable(),
         started = SharingStarted.WhileSubscribed(SheetWhileSubscribed),
-        producer = { state, _ ->
+        producer = { state, actions ->
             launchLoadSignedInProfileMutations(
                 state = state,
                 authRepository = authRepository,
@@ -49,6 +50,16 @@ class EmbeddableRecordOptionsViewModel(
                 state = state,
                 messageRepository = messageRepository,
             )
+            actions.launchMutationsIn(
+                productionScope = this,
+                keySelector = EmbeddableRecordOptionsAction::key,
+            ) {
+                when (val action = type()) {
+                    is EmbeddableRecordOptionsAction.SetEditTitle -> action.flow.launchAndCollect {
+                        state.editTitle = it.title
+                    }
+                }
+            }
         },
     )
 
@@ -75,7 +86,10 @@ interface EmbeddableRecordOptionsState {
     data class Immutable(
         val signedInProfileId: ProfileId? = null,
         val recentConversations: List<Conversation> = emptyList(),
+        val editTitle: String? = null,
     ) : EmbeddableRecordOptionsState
 }
 
-sealed class EmbeddableRecordOptionsAction(val key: String)
+sealed class EmbeddableRecordOptionsAction(val key: String) {
+    data class SetEditTitle(val title: String?) : EmbeddableRecordOptionsAction("SetEditTitle")
+}

--- a/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/ui/sheets/embedrecordoptions/EmbeddableRecordOptionsStateHolder.kt
+++ b/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/ui/sheets/embedrecordoptions/EmbeddableRecordOptionsStateHolder.kt
@@ -1,0 +1,81 @@
+package com.tunjid.heron.timeline.ui.sheets.embedrecordoptions
+
+import androidx.compose.runtime.Stable
+import androidx.lifecycle.ViewModel
+import com.tunjid.heron.data.core.models.Conversation
+import com.tunjid.heron.data.core.types.ProfileId
+import com.tunjid.heron.data.repository.AuthRepository
+import com.tunjid.heron.data.repository.MessageRepository
+import com.tunjid.heron.data.repository.recentConversations
+import com.tunjid.heron.timeline.utilities.SheetWhileSubscribed
+import com.tunjid.heron.ui.coroutines.launchAndCollect
+import com.tunjid.mutator.coroutines.ActionSuspendingStateMutator
+import com.tunjid.mutator.coroutines.actionSuspendingStateMutator
+import com.tunjid.snapshottable.SnapshotSpec
+import com.tunjid.snapshottable.Snapshottable
+import dev.zacsweers.metro.Assisted
+import dev.zacsweers.metro.AssistedFactory
+import dev.zacsweers.metro.AssistedInject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.serialization.Serializable
+
+typealias EmbeddableRecordOptionsStateHolder =
+    ActionSuspendingStateMutator<EmbeddableRecordOptionsAction, EmbeddableRecordOptionsState>
+
+@AssistedFactory
+fun interface EmbeddableRecordOptionsViewModelInitializer {
+    fun invoke(
+        scope: CoroutineScope,
+    ): EmbeddableRecordOptionsViewModel
+}
+
+@AssistedInject
+class EmbeddableRecordOptionsViewModel(
+    authRepository: AuthRepository,
+    messageRepository: MessageRepository,
+    @Assisted scope: CoroutineScope,
+) : ViewModel(viewModelScope = scope),
+    EmbeddableRecordOptionsStateHolder by scope.actionSuspendingStateMutator(
+        state = EmbeddableRecordOptionsState.Immutable().toSnapshotMutable(),
+        started = SharingStarted.WhileSubscribed(SheetWhileSubscribed),
+        producer = { state, _ ->
+            launchLoadSignedInProfileMutations(
+                state = state,
+                authRepository = authRepository,
+            )
+            launchLoadRecentConversationsMutations(
+                state = state,
+                messageRepository = messageRepository,
+            )
+        },
+    )
+
+context(productionScope: CoroutineScope)
+private fun launchLoadSignedInProfileMutations(
+    state: EmbeddableRecordOptionsState.SnapshotMutable,
+    authRepository: AuthRepository,
+) = authRepository.signedInUser
+    .distinctUntilChanged()
+    .launchAndCollect { state.signedInProfileId = it?.did }
+
+context(productionScope: CoroutineScope)
+private fun launchLoadRecentConversationsMutations(
+    state: EmbeddableRecordOptionsState.SnapshotMutable,
+    messageRepository: MessageRepository,
+) = messageRepository.recentConversations()
+    .launchAndCollect { state.recentConversations = it }
+
+@Stable
+@Snapshottable
+interface EmbeddableRecordOptionsState {
+    @SnapshotSpec
+    @Serializable
+    data class Immutable(
+        val signedInProfileId: ProfileId? = null,
+        val recentConversations: List<Conversation> = emptyList(),
+    ) : EmbeddableRecordOptionsState
+}
+
+sealed class EmbeddableRecordOptionsAction(val key: String)

--- a/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/utilities/SheetsViewModelInitializers.kt
+++ b/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/utilities/SheetsViewModelInitializers.kt
@@ -1,5 +1,6 @@
 package com.tunjid.heron.timeline.utilities
 
+import com.tunjid.heron.timeline.ui.sheets.embedrecordoptions.EmbeddableRecordOptionsViewModelInitializer
 import com.tunjid.heron.timeline.ui.sheets.mutedwords.MutedWordsViewModelInitializer
 import com.tunjid.heron.timeline.ui.sheets.postoptions.PostOptionsViewModelInitializer
 import com.tunjid.heron.timeline.ui.sheets.threadgate.ThreadGateViewModelInitializer
@@ -8,5 +9,6 @@ class SheetsViewModelInitializers(
     val mutedWordsViewModelInitializer: MutedWordsViewModelInitializer,
     val postOptionsViewModelInitializer: PostOptionsViewModelInitializer,
     val threadGateViewModelInitializer: ThreadGateViewModelInitializer,
-    // next sheet added here as migration continues
+    val embeddableRecordOptionsViewModelInitializer: EmbeddableRecordOptionsViewModelInitializer,
+
 )


### PR DESCRIPTION
### What
- Migrates `EmbeddableRecordOptionsSheetState` to the ViewModel-backed pattern.

### Changes
- `EmbeddableRecordOptionsViewModel` with `@AssistedInject`, `@Snapshottable`  state, loads sheet read mutations
- Implement `EmbeddableRecordOptionsSheetState` as `PaneScaffoldState` ext
- Implement `EmbeddableRecordOptionsSheetState` in feature modules


