### PR TITLE
Migrate SelectedListSheetState to viewmodel backed state

### DIFF
--- a/feature/graze-editor/src/commonMain/kotlin/com/tunjid/heron/graze/editor/GrazeEditorScreen.kt
+++ b/feature/graze-editor/src/commonMain/kotlin/com/tunjid/heron/graze/editor/GrazeEditorScreen.kt
@@ -41,7 +41,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier

--- a/feature/graze-editor/src/commonMain/kotlin/com/tunjid/heron/graze/editor/GrazeEditorScreen.kt
+++ b/feature/graze-editor/src/commonMain/kotlin/com/tunjid/heron/graze/editor/GrazeEditorScreen.kt
@@ -48,7 +48,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
-import com.tunjid.heron.data.core.models.FeedList
 import com.tunjid.heron.data.core.models.Profile
 import com.tunjid.heron.data.graze.Filter
 import com.tunjid.heron.graze.editor.ui.filter.AnalysisFilter
@@ -151,10 +150,6 @@ fun GrazeEditorScreen(
                             animatedVisibilityScope = this@NestedNavigation,
                             paneScaffoldState = paneScaffoldState,
                             profileSearchResults = state.suggestedProfiles,
-                            recentLists = state.recentLists,
-                            onUpdateRecentLists = {
-                                actions(Action.UpdateRecentLists)
-                            },
                             filter = child,
                             atTopLevel = true,
                             onProfileQueryChanged = { query ->
@@ -235,7 +230,6 @@ fun GrazeEditorScreen(
 
     // Using Disposable effect as there's no need for a CoroutineScope
     DisposableEffect(hasList) {
-        if (hasList) actions(Action.UpdateRecentLists)
         onDispose { }
     }
 }
@@ -247,8 +241,6 @@ private fun Filter(
     paneScaffoldState: PaneScaffoldState,
     filter: Filter,
     profileSearchResults: List<Profile>,
-    recentLists: List<FeedList>,
-    onUpdateRecentLists: () -> Unit,
     atTopLevel: Boolean,
     path: List<Int>,
     enterFilter: (Int) -> Unit,
@@ -265,8 +257,6 @@ private fun Filter(
         modifier = modifier,
         filter = filter,
         profileSearchResults = profileSearchResults,
-        recentLists = recentLists,
-        onUpdateRecentLists = onUpdateRecentLists,
         index = index,
         path = path,
         onProfileQueryChanged = onProfileQueryChanged,
@@ -276,11 +266,10 @@ private fun Filter(
         onRemoveFilter = onRemoveFilter,
     )
     else FilterLeaf(
+        paneScaffoldState = paneScaffoldState,
         modifier = modifier,
         filter = filter,
         profileSearchResults = profileSearchResults,
-        recentLists = recentLists,
-        onUpdateRecentLists = onUpdateRecentLists,
         onProfileQueryChanged = onProfileQueryChanged,
         onUpdate = { updatedFilter ->
             onUpdateFilter(
@@ -307,8 +296,6 @@ fun FilterRow(
     filter: Filter.Root,
     path: List<Int>,
     profileSearchResults: List<Profile>,
-    recentLists: List<FeedList>,
-    onUpdateRecentLists: () -> Unit,
     onProfileQueryChanged: (String) -> Unit,
     enterFilter: (Int) -> Unit,
     onFlipClicked: (path: List<Int>) -> Unit,
@@ -376,8 +363,6 @@ fun FilterRow(
                                 animatedVisibilityScope = animatedVisibilityScope,
                                 paneScaffoldState = paneScaffoldState,
                                 profileSearchResults = profileSearchResults,
-                                recentLists = recentLists,
-                                onUpdateRecentLists = onUpdateRecentLists,
                                 filter = child,
                                 atTopLevel = false,
                                 index = childIndex,
@@ -476,10 +461,9 @@ private fun RootFilterDescription(
 
 @Composable
 fun FilterLeaf(
+    paneScaffoldState: PaneScaffoldState,
     filter: Filter,
     profileSearchResults: List<Profile>,
-    recentLists: List<FeedList>,
-    onUpdateRecentLists: () -> Unit,
     onProfileQueryChanged: (String) -> Unit,
     onUpdate: (Filter) -> Unit,
     onRemove: () -> Unit,
@@ -539,14 +523,14 @@ fun FilterLeaf(
             onUpdate = onUpdate,
             onRemove = onRemove,
         )
-        is Filter.Social.ListMember -> SocialListMemberFilter(
-            modifier = modifier,
-            filter = filter,
-            recentLists = recentLists,
-            onUpdateRecentLists = onUpdateRecentLists,
-            onUpdate = onUpdate,
-            onRemove = onRemove,
-        )
+        is Filter.Social.ListMember -> with(paneScaffoldState) {
+            SocialListMemberFilter(
+                modifier = modifier,
+                filter = filter,
+                onUpdate = onUpdate,
+                onRemove = onRemove,
+            )
+        }
         is Filter.Social.MagicAudience -> SocialMagicAudienceFilter(
             modifier = modifier,
             filter = filter,

--- a/feature/graze-editor/src/commonMain/kotlin/com/tunjid/heron/graze/editor/GrazeEditorScreen.kt
+++ b/feature/graze-editor/src/commonMain/kotlin/com/tunjid/heron/graze/editor/GrazeEditorScreen.kt
@@ -223,15 +223,6 @@ fun GrazeEditorScreen(
             }
         }
     }
-
-    val hasList = state.currentFilter
-        .filters
-        .any { it is Filter.Social.ListMember }
-
-    // Using Disposable effect as there's no need for a CoroutineScope
-    DisposableEffect(hasList) {
-        onDispose { }
-    }
 }
 
 @Composable
@@ -523,14 +514,12 @@ fun FilterLeaf(
             onUpdate = onUpdate,
             onRemove = onRemove,
         )
-        is Filter.Social.ListMember -> with(paneScaffoldState) {
-            SocialListMemberFilter(
-                modifier = modifier,
-                filter = filter,
-                onUpdate = onUpdate,
-                onRemove = onRemove,
-            )
-        }
+        is Filter.Social.ListMember -> paneScaffoldState.SocialListMemberFilter(
+            modifier = modifier,
+            filter = filter,
+            onUpdate = onUpdate,
+            onRemove = onRemove,
+        )
         is Filter.Social.MagicAudience -> SocialMagicAudienceFilter(
             modifier = modifier,
             filter = filter,

--- a/feature/graze-editor/src/commonMain/kotlin/com/tunjid/heron/graze/editor/GrazeEditorViewModel.kt
+++ b/feature/graze-editor/src/commonMain/kotlin/com/tunjid/heron/graze/editor/GrazeEditorViewModel.kt
@@ -113,9 +113,6 @@ class ActualGrazeEditorViewModel(
                         is Action.EditorNavigation -> action.flow.editorNavigationMutations()
                         is Action.EditFilter -> action.flow.editFilterFilterMutations()
                         is Action.Metadata -> action.flow.updateMetadataMutations()
-                        is Action.UpdateRecentLists -> action.flow.recentListsMutations(
-                            recordRepository = recordRepository,
-                        )
                     }
                 }
         },
@@ -270,16 +267,6 @@ private fun Flow<Action.EditFilter>.editFilterFilterMutations(): Flow<Mutation<S
                 is GrazeFeed.Pending -> currentFeed.copy(filter = editedFilter)
             },
         )
-    }
-
-fun Flow<Action.UpdateRecentLists>.recentListsMutations(
-    recordRepository: RecordRepository,
-): Flow<Mutation<State>> =
-    flatMapLatest {
-        recordRepository.recentLists
-            .mapToMutation { lists ->
-                copy(recentLists = lists)
-            }
     }
 
 private fun Filter.Root.updateAt(

--- a/feature/graze-editor/src/commonMain/kotlin/com/tunjid/heron/graze/editor/State.kt
+++ b/feature/graze-editor/src/commonMain/kotlin/com/tunjid/heron/graze/editor/State.kt
@@ -44,8 +44,6 @@ data class State(
     val sharedElementPrefix: String,
     val isLoading: Boolean = false,
     @Transient
-    val recentLists: List<FeedList> = emptyList(),
-    @Transient
     val suggestedProfiles: List<Profile> = emptyList(),
     @Transient
     val messages: List<Memo> = emptyList(),
@@ -121,8 +119,6 @@ sealed class Action(val key: String) {
         val displayName: String,
         val description: String?,
     ) : Action("Metadata")
-
-    data object UpdateRecentLists : Action(key = "UpdateRecentLists")
 
     sealed class Navigate :
         Action(key = "Navigate"),

--- a/feature/graze-editor/src/commonMain/kotlin/com/tunjid/heron/graze/editor/ui/filter/SocialFilters.kt
+++ b/feature/graze-editor/src/commonMain/kotlin/com/tunjid/heron/graze/editor/ui/filter/SocialFilters.kt
@@ -32,6 +32,7 @@ import com.tunjid.heron.data.graze.Filter
 import com.tunjid.heron.scaffold.scaffold.PaneScaffoldState
 import com.tunjid.heron.scaffold.scaffold.rememberSelectListSheetState
 import com.tunjid.heron.timeline.ui.sheets.SelectTextSheetState.Companion.rememberSelectProfileHandleState
+import com.tunjid.mutator.compose.produceState
 import heron.feature.graze_editor.generated.resources.Res
 import heron.feature.graze_editor.generated.resources.add_profile
 import heron.feature.graze_editor.generated.resources.direction
@@ -219,6 +220,11 @@ fun PaneScaffoldState.SocialListMemberFilter(
             onUpdate(filter.copy(url = list.uri.uri))
         },
     )
+    val selectListState = sheetState.viewModel.produceState()
+    val displayValue = selectListState.lists
+        .find { it.uri.uri == filter.url }
+        ?.name
+        ?: filter.url
     StandardFilter(
         modifier = modifier,
         tint = filter.validationTint(),
@@ -241,7 +247,7 @@ fun PaneScaffoldState.SocialListMemberFilter(
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 OutlinedTextField(
-                    value = filter.url,
+                    value = displayValue,
                     onValueChange = {},
                     readOnly = true,
                     label = {

--- a/feature/graze-editor/src/commonMain/kotlin/com/tunjid/heron/graze/editor/ui/filter/SocialFilters.kt
+++ b/feature/graze-editor/src/commonMain/kotlin/com/tunjid/heron/graze/editor/ui/filter/SocialFilters.kt
@@ -27,10 +27,10 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.tunjid.heron.data.core.models.FeedList
 import com.tunjid.heron.data.core.models.Profile
 import com.tunjid.heron.data.graze.Filter
-import com.tunjid.heron.timeline.ui.SelectListSheetState.Companion.rememberSelectListSheetState
+import com.tunjid.heron.scaffold.scaffold.PaneScaffoldState
+import com.tunjid.heron.scaffold.scaffold.rememberSelectListSheetState
 import com.tunjid.heron.timeline.ui.sheets.SelectTextSheetState.Companion.rememberSelectProfileHandleState
 import heron.feature.graze_editor.generated.resources.Res
 import heron.feature.graze_editor.generated.resources.add_profile
@@ -208,20 +208,15 @@ fun SocialStarterPackFilter(
 }
 
 @Composable
-fun SocialListMemberFilter(
+fun PaneScaffoldState.SocialListMemberFilter(
     filter: Filter.Social.ListMember,
-    recentLists: List<FeedList>,
-    onUpdateRecentLists: () -> Unit,
     onUpdate: (Filter.Social.ListMember) -> Unit,
     onRemove: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val sheetState = rememberSelectListSheetState(
-        lists = recentLists,
         onListSelected = { list ->
-            onUpdate(
-                filter.copy(url = list.uri.uri),
-            )
+            onUpdate(filter.copy(url = list.uri.uri))
         },
     )
     StandardFilter(
@@ -246,7 +241,7 @@ fun SocialListMemberFilter(
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 OutlinedTextField(
-                    value = recentLists.find { it.uri.uri == filter.url }?.name ?: filter.url,
+                    value = filter.url,
                     onValueChange = {},
                     readOnly = true,
                     label = {
@@ -258,7 +253,6 @@ fun SocialListMemberFilter(
 
                 FilledTonalButton(
                     onClick = {
-                        onUpdateRecentLists()
                         sheetState.show()
                     },
                     modifier = Modifier

--- a/feature/graze-editor/src/commonMain/kotlin/com/tunjid/heron/graze/editor/ui/filter/SocialFilters.kt
+++ b/feature/graze-editor/src/commonMain/kotlin/com/tunjid/heron/graze/editor/ui/filter/SocialFilters.kt
@@ -220,8 +220,7 @@ fun PaneScaffoldState.SocialListMemberFilter(
             onUpdate(filter.copy(url = list.uri.uri))
         },
     )
-    val selectListState = sheetState.viewModel.produceState()
-    val displayValue = selectListState.lists
+    val displayValue = sheetState.state.lists
         .find { it.uri.uri == filter.url }
         ?.name
         ?: filter.url

--- a/scaffold/src/commonMain/kotlin/com/tunjid/heron/scaffold/scaffold/PaneSheets.kt
+++ b/scaffold/src/commonMain/kotlin/com/tunjid/heron/scaffold/scaffold/PaneSheets.kt
@@ -2,6 +2,7 @@ package com.tunjid.heron.scaffold.scaffold
 
 import androidx.compose.runtime.Composable
 import com.tunjid.heron.data.core.models.Conversation
+import com.tunjid.heron.data.core.models.FeedList
 import com.tunjid.heron.data.core.models.Post
 import com.tunjid.heron.data.core.models.PostInteractionSettingsPreference
 import com.tunjid.heron.data.core.types.EmbeddableRecordUri
@@ -9,6 +10,7 @@ import com.tunjid.heron.timeline.ui.sheets.embedrecordoptions.EmbeddableRecordOp
 import com.tunjid.heron.timeline.ui.sheets.mutedwords.MutedWordsSheetState
 import com.tunjid.heron.timeline.ui.sheets.postoptions.PostOption
 import com.tunjid.heron.timeline.ui.sheets.postoptions.PostOptionsSheetState
+import com.tunjid.heron.timeline.ui.sheets.selectlist.SelectListSheetState
 import com.tunjid.heron.timeline.ui.sheets.threadgate.ThreadGateSheetState
 
 @Composable
@@ -57,4 +59,13 @@ fun PaneScaffoldState.rememberEmbeddableRecordOptionsSheetState(
         onEditClicked = onEditClicked,
         onShareInConversationClicked = onShareInConversationClicked,
         onShareInPostClicked = onShareInPostClicked,
+    )
+
+@Composable
+fun PaneScaffoldState.rememberSelectListSheetState(
+    onListSelected: (FeedList) -> Unit,
+): SelectListSheetState =
+    SelectListSheetState.rememberUpdatedSelectListSheetState(
+        initializer = appState.sheetsViewModelInitializers.selectListViewModelInitializer,
+        onListSelected = onListSelected,
     )

--- a/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/di/Bindings.kt
+++ b/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/di/Bindings.kt
@@ -20,6 +20,7 @@ import com.tunjid.heron.data.di.DataBindings
 import com.tunjid.heron.timeline.ui.sheets.embedrecordoptions.EmbeddableRecordOptionsViewModelInitializer
 import com.tunjid.heron.timeline.ui.sheets.mutedwords.MutedWordsViewModelInitializer
 import com.tunjid.heron.timeline.ui.sheets.postoptions.PostOptionsViewModelInitializer
+import com.tunjid.heron.timeline.ui.sheets.selectlist.SelectListViewModelInitializer
 import com.tunjid.heron.timeline.ui.sheets.threadgate.ThreadGateViewModelInitializer
 import com.tunjid.heron.timeline.utilities.SheetsViewModelInitializers
 import dev.zacsweers.metro.BindingContainer
@@ -36,10 +37,12 @@ class SheetBindings(
         postOptionsViewModelInitializer: PostOptionsViewModelInitializer,
         threadGateViewModelInitializer: ThreadGateViewModelInitializer,
         embeddableRecordOptionsViewModelInitializer: EmbeddableRecordOptionsViewModelInitializer,
+        selectListViewModelInitializer: SelectListViewModelInitializer,
     ): SheetsViewModelInitializers = SheetsViewModelInitializers(
         mutedWordsViewModelInitializer = mutedWordsViewModelInitializer,
         postOptionsViewModelInitializer = postOptionsViewModelInitializer,
         threadGateViewModelInitializer = threadGateViewModelInitializer,
         embeddableRecordOptionsViewModelInitializer = embeddableRecordOptionsViewModelInitializer,
+        selectListViewModelInitializer = selectListViewModelInitializer,
     )
 }

--- a/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/ui/sheets/selectlist/SelectListSheetState.kt
+++ b/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/ui/sheets/selectlist/SelectListSheetState.kt
@@ -41,8 +41,11 @@ import com.tunjid.mutator.compose.produceState
 @Stable
 class SelectListSheetState(
     scope: BottomSheetScope,
-    val viewModel: SelectListViewModel,
+    internal val viewModel: SelectListViewModel,
 ) : BottomSheetState(scope) {
+
+    val state: SelectListState
+        get() = viewModel.state
 
     override fun onHidden() {
         // No-op

--- a/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/ui/sheets/selectlist/SelectListSheetState.kt
+++ b/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/ui/sheets/selectlist/SelectListSheetState.kt
@@ -41,7 +41,7 @@ import com.tunjid.mutator.compose.produceState
 @Stable
 class SelectListSheetState(
     scope: BottomSheetScope,
-    internal val viewModel: SelectListViewModel,
+    val viewModel: SelectListViewModel,
 ) : BottomSheetState(scope) {
 
     override fun onHidden() {

--- a/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/ui/sheets/selectlist/SelectListSheetState.kt
+++ b/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/ui/sheets/selectlist/SelectListSheetState.kt
@@ -14,7 +14,7 @@
  *    limitations under the License.
  */
 
-package com.tunjid.heron.timeline.ui
+package com.tunjid.heron.timeline.ui.sheets.selectlist
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
@@ -27,9 +27,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -39,13 +36,13 @@ import com.tunjid.heron.ui.sheets.BottomSheetScope
 import com.tunjid.heron.ui.sheets.BottomSheetScope.Companion.ModalBottomSheet
 import com.tunjid.heron.ui.sheets.BottomSheetScope.Companion.rememberBottomSheetState
 import com.tunjid.heron.ui.sheets.BottomSheetState
+import com.tunjid.mutator.compose.produceState
 
 @Stable
-class SelectListSheetState private constructor(
-    lists: List<FeedList>,
+class SelectListSheetState(
     scope: BottomSheetScope,
+    internal val viewModel: SelectListViewModel,
 ) : BottomSheetState(scope) {
-    internal var lists by mutableStateOf(lists)
 
     override fun onHidden() {
         // No-op
@@ -53,18 +50,14 @@ class SelectListSheetState private constructor(
 
     companion object {
         @Composable
-        fun rememberSelectListSheetState(
-            lists: List<FeedList>,
+        fun rememberUpdatedSelectListSheetState(
+            initializer: SelectListViewModelInitializer,
             onListSelected: (FeedList) -> Unit,
         ): SelectListSheetState {
-            val state = rememberBottomSheetState {
-                SelectListSheetState(
-                    lists = lists,
-                    scope = it,
-                )
-            }.also {
-                it.lists = lists
-            }
+            val state = rememberBottomSheetState(
+                viewModelInitializer = initializer::invoke,
+                block = ::SelectListSheetState,
+            )
 
             SelectListBottomSheet(
                 state = state,
@@ -82,12 +75,14 @@ private fun SelectListBottomSheet(
     onListSelected: (FeedList) -> Unit,
 ) {
     state.ModalBottomSheet {
+        val selectListState = state.viewModel.produceState()
+
         LazyColumn(
             contentPadding = PaddingValues(16.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             items(
-                items = state.lists,
+                items = selectListState.lists,
                 key = { it.uri.uri },
             ) { list ->
                 BottomSheetItemCard(

--- a/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/ui/sheets/selectlist/SelectListStateHolder.kt
+++ b/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/ui/sheets/selectlist/SelectListStateHolder.kt
@@ -1,0 +1,62 @@
+package com.tunjid.heron.timeline.ui.sheets.selectlist
+
+import androidx.compose.runtime.Stable
+import androidx.lifecycle.ViewModel
+import com.tunjid.heron.data.core.models.FeedList
+import com.tunjid.heron.data.repository.RecordRepository
+import com.tunjid.heron.timeline.utilities.SheetWhileSubscribed
+import com.tunjid.heron.ui.coroutines.launchAndCollect
+import com.tunjid.mutator.coroutines.ActionSuspendingStateMutator
+import com.tunjid.mutator.coroutines.actionSuspendingStateMutator
+import com.tunjid.snapshottable.SnapshotSpec
+import com.tunjid.snapshottable.Snapshottable
+import dev.zacsweers.metro.Assisted
+import dev.zacsweers.metro.AssistedFactory
+import dev.zacsweers.metro.AssistedInject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.serialization.Serializable
+
+typealias SelectListStateHolder = ActionSuspendingStateMutator<SelectListAction, SelectListState>
+
+@AssistedFactory
+fun interface SelectListViewModelInitializer {
+    fun invoke(
+        scope: CoroutineScope,
+    ): SelectListViewModel
+}
+
+@AssistedInject
+class SelectListViewModel(
+    recordRepository: RecordRepository,
+    @Assisted scope: CoroutineScope,
+) : ViewModel(viewModelScope = scope),
+    SelectListStateHolder by scope.actionSuspendingStateMutator(
+        state = SelectListState.Immutable().toSnapshotMutable(),
+        started = SharingStarted.WhileSubscribed(SheetWhileSubscribed),
+        producer = { state, _ ->
+            launchLoadListsMutations(
+                state = state,
+                recordRepository = recordRepository,
+            )
+        },
+    )
+
+context(productionScope: CoroutineScope)
+private fun launchLoadListsMutations(
+    state: SelectListState.SnapshotMutable,
+    recordRepository: RecordRepository,
+) = recordRepository.recentLists
+    .launchAndCollect { state.lists = it }
+
+@Stable
+@Snapshottable
+interface SelectListState {
+    @SnapshotSpec
+    @Serializable
+    data class Immutable(
+        val lists: List<FeedList> = emptyList(),
+    ) : SelectListState
+}
+
+sealed class SelectListAction(val key: String)

--- a/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/ui/sheets/selectlist/SelectListStateHolder.kt
+++ b/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/ui/sheets/selectlist/SelectListStateHolder.kt
@@ -5,9 +5,9 @@ import androidx.lifecycle.ViewModel
 import com.tunjid.heron.data.core.models.FeedList
 import com.tunjid.heron.data.repository.RecordRepository
 import com.tunjid.heron.timeline.utilities.SheetWhileSubscribed
-import com.tunjid.heron.ui.coroutines.launchAndCollect
 import com.tunjid.mutator.coroutines.ActionSuspendingStateMutator
 import com.tunjid.mutator.coroutines.actionSuspendingStateMutator
+import com.tunjid.mutator.coroutines.launchedCollect
 import com.tunjid.snapshottable.SnapshotSpec
 import com.tunjid.snapshottable.Snapshottable
 import dev.zacsweers.metro.Assisted
@@ -47,7 +47,7 @@ private fun launchLoadListsMutations(
     state: SelectListState.SnapshotMutable,
     recordRepository: RecordRepository,
 ) = recordRepository.recentLists
-    .launchAndCollect { state.lists = it }
+    .launchedCollect { state.lists = it }
 
 @Stable
 @Snapshottable

--- a/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/utilities/SheetsViewModelInitializers.kt
+++ b/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/utilities/SheetsViewModelInitializers.kt
@@ -3,6 +3,7 @@ package com.tunjid.heron.timeline.utilities
 import com.tunjid.heron.timeline.ui.sheets.embedrecordoptions.EmbeddableRecordOptionsViewModelInitializer
 import com.tunjid.heron.timeline.ui.sheets.mutedwords.MutedWordsViewModelInitializer
 import com.tunjid.heron.timeline.ui.sheets.postoptions.PostOptionsViewModelInitializer
+import com.tunjid.heron.timeline.ui.sheets.selectlist.SelectListViewModelInitializer
 import com.tunjid.heron.timeline.ui.sheets.threadgate.ThreadGateViewModelInitializer
 
 class SheetsViewModelInitializers(
@@ -10,5 +11,5 @@ class SheetsViewModelInitializers(
     val postOptionsViewModelInitializer: PostOptionsViewModelInitializer,
     val threadGateViewModelInitializer: ThreadGateViewModelInitializer,
     val embeddableRecordOptionsViewModelInitializer: EmbeddableRecordOptionsViewModelInitializer,
-
+    val selectListViewModelInitializer: SelectListViewModelInitializer,
 )


### PR DESCRIPTION

### What
- Migrates `SelectListSheetState` to the ViewModel-backed pattern

### Why
`recentLists` was previously threaded through `Filter` to `FilterLeaf` to `SocialListMemberFilter`, with `onUpdateRecentLists` dispatched from the
feature ViewModel to trigger loading. This coupled a generic, reusable picker sheet to feature-specific state and action plumbing.

### How

**ViewModel**
`SelectListViewModel` is `@AssistedInject`, `@Snapshottable` state, loads `recentLists` via `launchAndCollect` in the producer block same source (`RecordRepository.recentLists`) as `ThreadGateViewModel`.

**SheetState**
`SelectListSheetState` receives the ViewModel directly via the new`rememberBottomSheetState` overload. `lists` moves from a`mutableStateOf` field into ViewModel state, read via `produceState()`in the bottom sheet composable.

**`onListSelected` stays a callback**
`SelectListSheetState` is a shared picker used across multiple
features; what happens with the selected list differs per call site
(filter update, thread gate audience, etc.), so the ViewModel only owns loading; selection handling remains the feature's responsibility.

**Removed from the filter chain**
- `recentLists` and `onUpdateRecentLists` removed from `Filter`, `GrazeEditorViewModel` and `State`
`FilterLeaf`, and `SocialListMemberFilter`. 
- `SocialListMemberFilter`is now a `PaneScaffoldState` extension and creates its sheet state via `rememberSelectListSheetState`. `PaneScaffoldState` is threaded through
- `Filter` to `FilterLeaf` to support this.

**PaneScaffoldState extension**
```kotlin
fun PaneScaffoldState.rememberSelectListSheetState(
    onListSelected: (FeedList) -> Unit,
): SelectListSheetState
```

### Note
The list name display previously resolved via
`recentLists.find { it.uri.uri == filter.url }?.name` now falls back to
`filter.url` directly, since `recentLists` is no longer passed in.
Resolving the display name from the sheet's ViewModel state would be a follow-up if needed.
