### PR TITLE
feat: add toggle to hide replies from people you don't follow

### DIFF
--- a/data/core/src/commonMain/kotlin/com/tunjid/heron/data/repository/TimelineRepository.kt
+++ b/data/core/src/commonMain/kotlin/com/tunjid/heron/data/repository/TimelineRepository.kt
@@ -42,6 +42,7 @@ import com.tunjid.heron.data.core.models.FeedPreference
 import com.tunjid.heron.data.core.models.FeedPreference.Companion.homeFeedOrDefault
 import com.tunjid.heron.data.core.models.FeedPreference.Companion.shouldHideQuotes
 import com.tunjid.heron.data.core.models.FeedPreference.Companion.shouldHideReplies
+import com.tunjid.heron.data.core.models.FeedPreference.Companion.shouldHideRepliesByUnfollowed
 import com.tunjid.heron.data.core.models.FeedPreference.Companion.shouldHideReposts
 import com.tunjid.heron.data.core.models.Post
 import com.tunjid.heron.data.core.models.Preferences
@@ -897,6 +898,7 @@ internal class OfflineTimelineRepository(
                                     limit = 1,
                                     offset = 0,
                                     hideReplies = feedPreference.shouldHideReplies,
+                                    hideRepliesByUnfollowed = feedPreference.shouldHideRepliesByUnfollowed,
                                     hideReposts = feedPreference.shouldHideReposts,
                                     hideQuotePosts = feedPreference.shouldHideQuotes,
                                 )
@@ -908,6 +910,7 @@ internal class OfflineTimelineRepository(
                             limit = 1,
                             offset = 0,
                             hideReplies = feedPreference.shouldHideReplies,
+                            hideRepliesByUnfollowed = feedPreference.shouldHideRepliesByUnfollowed,
                             hideReposts = feedPreference.shouldHideReposts,
                             hideQuotePosts = feedPreference.shouldHideQuotes,
                         ),
@@ -944,6 +947,7 @@ internal class OfflineTimelineRepository(
                         offset = query.data.offset,
                         limit = query.data.limit,
                         hideReplies = feedPreference.shouldHideReplies,
+                        hideRepliesByUnfollowed = feedPreference.shouldHideRepliesByUnfollowed,
                         hideReposts = feedPreference.shouldHideReposts,
                         hideQuotePosts = feedPreference.shouldHideQuotes,
                     )
@@ -1362,7 +1366,14 @@ private fun SavedStateDataSource.timelineFeedPreference(
         .distinctUntilChangedMap {
             it.signedProfilePreferencesOrDefault().feedPreferences.homeFeedOrDefault()
         }
-    else flowOf(FeedPreference(source.id))
+    else flowOf(
+        // hideRepliesByUnfollowed defaults to true on FeedPreference; disable it for
+        // sources without the toggle so replies are only hidden on the following feed.
+        FeedPreference(
+            feed = source.id,
+            hideRepliesByUnfollowed = false,
+        ),
+    )
 
 private val TimelineItem.Threaded.Linear.nextGeneration
     get() = generation?.let { it + nodes.size }

--- a/data/database/src/commonMain/kotlin/com/tunjid/heron/data/database/daos/TimelineDao.kt
+++ b/data/database/src/commonMain/kotlin/com/tunjid/heron/data/database/daos/TimelineDao.kt
@@ -84,6 +84,18 @@ interface TimelineDao {
                 OR parentPostUri IS NULL
             )
             AND (
+                :hideRepliesByUnfollowed = FALSE
+                OR parentPostUri IS NULL
+                OR EXISTS (
+                    SELECT 1 FROM posts
+                    LEFT JOIN profileViewerStates
+                        ON profileViewerStates.profileId = :viewingProfileId
+                        AND profileViewerStates.otherProfileId = posts.authorId
+                    WHERE posts.uri = timelineItems.parentPostUri
+                    AND profileViewerStates.following IS NOT NULL
+                )
+            )
+            AND (
                 :hideReposts = FALSE
                 OR reposter IS NULL
             )
@@ -105,6 +117,7 @@ interface TimelineDao {
         limit: Long,
         offset: Long,
         hideReplies: Boolean,
+        hideRepliesByUnfollowed: Boolean,
         hideReposts: Boolean,
         hideQuotePosts: Boolean,
     ): Flow<List<PopulatedTimelineItemEntity>>

--- a/data/models/src/commonMain/kotlin/com/tunjid/heron/data/core/models/Preferences.kt
+++ b/data/models/src/commonMain/kotlin/com/tunjid/heron/data/core/models/Preferences.kt
@@ -225,6 +225,9 @@ data class FeedPreference(
         val FeedPreference.shouldHideReplies: Boolean
             get() = hideReplies.isTrue
 
+        val FeedPreference.shouldHideRepliesByUnfollowed: Boolean
+            get() = hideRepliesByUnfollowed.isTrue
+
         val FeedPreference.shouldHideReposts: Boolean
             get() = hideReposts.isTrue
 

--- a/feature/settings/src/commonMain/composeResources/values/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values/strings.xml
@@ -61,6 +61,7 @@
     <string name="following_feed_preferences">Following Feed Preferences</string>
     <string name="thread_preferences">Thread Preferences</string>
     <string name="timeline_preferences_replies">Hide replies</string>
+    <string name="timeline_preferences_replies_by_unfollowed">Hide replies from people you don\'t follow</string>
     <string name="timeline_preferences_reposts">Hide reposts</string>
     <string name="timeline_preferences_quote_reposts">Hide quote posts</string>
 </resources>

--- a/feature/settings/src/commonMain/kotlin/com/tunjid/heron/settings/ui/NestedFeedPreferences.kt
+++ b/feature/settings/src/commonMain/kotlin/com/tunjid/heron/settings/ui/NestedFeedPreferences.kt
@@ -22,10 +22,12 @@ import androidx.compose.ui.Modifier
 import com.tunjid.heron.data.core.models.FeedPreference
 import com.tunjid.heron.data.core.models.FeedPreference.Companion.shouldHideQuotes
 import com.tunjid.heron.data.core.models.FeedPreference.Companion.shouldHideReplies
+import com.tunjid.heron.data.core.models.FeedPreference.Companion.shouldHideRepliesByUnfollowed
 import com.tunjid.heron.data.core.models.FeedPreference.Companion.shouldHideReposts
 import heron.feature.settings.generated.resources.Res
 import heron.feature.settings.generated.resources.timeline_preferences_quote_reposts
 import heron.feature.settings.generated.resources.timeline_preferences_replies
+import heron.feature.settings.generated.resources.timeline_preferences_replies_by_unfollowed
 import heron.feature.settings.generated.resources.timeline_preferences_reposts
 import org.jetbrains.compose.resources.stringResource
 
@@ -42,6 +44,16 @@ fun FeedPreferencesSection(
         checked = feedPreference.shouldHideReplies,
         onCheckedChange = {
             onFeedPreferenceUpdated(feedPreference.copy(hideReplies = it))
+        },
+    )
+    SettingsToggleItem(
+        modifier = Modifier
+            .fillMaxWidth(),
+        text = stringResource(Res.string.timeline_preferences_replies_by_unfollowed),
+        enabled = true,
+        checked = feedPreference.shouldHideRepliesByUnfollowed,
+        onCheckedChange = {
+            onFeedPreferenceUpdated(feedPreference.copy(hideRepliesByUnfollowed = it))
         },
     )
     SettingsToggleItem(


### PR DESCRIPTION
## Summary
Adds a "Hide replies from people you don't follow" toggle to the Following feed preferences. When enabled alongside "Show Replies", replies addressed to accounts the signed-in user does not follow are filtered out of the feed, matching the behavior requested in #1354.

## Why this matters
The `FeedPreference` data model already carried a `hideRepliesByUnfollowed` field that was synced through the preference updater but never surfaced in the UI nor applied to the feed query. This change exposes that existing field:

- Adds a `shouldHideRepliesByUnfollowed` companion accessor mirroring `shouldHideReplies`.
- Adds a new `SettingsToggleItem` in `FeedPreferencesSection` bound to `feedPreference.copy(hideRepliesByUnfollowed = it)` with a new `timeline_preferences_replies_by_unfollowed` string.
- Threads a `hideRepliesByUnfollowed` parameter from the `TimelineRepository.feedItems(...)` call sites into `TimelineDao.feedItems(...)`, and extends the DAO `@Query` so a reply is kept only when its parent post author is followed (an `EXISTS` subquery joining `posts.uri = timelineItems.parentPostUri` to `profileViewerStates.following`).
- Scopes the filter to the following feed: non-following sources explicitly pass `hideRepliesByUnfollowed = false`, since the data-class default for this field is `true`.

The setting flows end to end: toggle in `NestedFeedPreferences` -> `FeedPreference.hideRepliesByUnfollowed` -> `shouldHideRepliesByUnfollowed` accessor -> `TimelineRepository.feedItems` -> `TimelineDao.feedItems` `@Query` filter, and persists through the existing preference updater sync.

## Testing
Manual verification against the test scenarios in the issue:
- Toggle off (default for non-following sources): replies from unfollowed authors remain visible.
- Toggle on with "Show Replies" enabled: replies to followed users still show, replies to unfollowed users are filtered out.
- Top-level (non-reply) posts are unaffected regardless of toggle state.
- Preference round-trips through the preference updater sync and persists across restart.

No schema migration is required: the change only adds a query parameter and SQL clause over the existing `timelineItems`, `posts`, and `profileViewerStates` tables. CI will validate the full Kotlin Multiplatform build.

Fixes #1354
