### PR TITLE
Migrate PostInteractionsSheetState to ViewModel-backed state

### DIFF
--- a/feature/feed/src/commonMain/kotlin/com/tunjid/heron/feed/FeedScreen.kt
+++ b/feature/feed/src/commonMain/kotlin/com/tunjid/heron/feed/FeedScreen.kt
@@ -61,6 +61,7 @@ import com.tunjid.heron.scaffold.navigation.signInDestination
 import com.tunjid.heron.scaffold.scaffold.PaneScaffoldState
 import com.tunjid.heron.scaffold.scaffold.paneClip
 import com.tunjid.heron.scaffold.scaffold.rememberMutedWordsSheetState
+import com.tunjid.heron.scaffold.scaffold.rememberPostInteractionsSheetState
 import com.tunjid.heron.scaffold.scaffold.rememberPostOptionsSheetState
 import com.tunjid.heron.scaffold.scaffold.rememberTimelineThreadGateSheetState
 import com.tunjid.heron.tiling.TilingState
@@ -73,7 +74,6 @@ import com.tunjid.heron.timeline.ui.PostAction
 import com.tunjid.heron.timeline.ui.PostActions
 import com.tunjid.heron.timeline.ui.TimelineItem
 import com.tunjid.heron.timeline.ui.effects.TimelineRefreshEffect
-import com.tunjid.heron.timeline.ui.post.PostInteractionsSheetState.Companion.rememberUpdatedPostInteractionsSheetState
 import com.tunjid.heron.timeline.ui.post.threadtraversal.ThreadedVideoPositionState.Companion.threadedVideoPosition
 import com.tunjid.heron.timeline.ui.post.threadtraversal.ThreadedVideoPositionStates
 import com.tunjid.heron.timeline.ui.profile.ProfileRestrictionDialogState.Companion.rememberProfileRestrictionDialogState
@@ -142,8 +142,7 @@ private fun FeedTimeline(
     val presentation = timelineState.timeline.presentation
     val displayState = rememberTimelineDisplayState()
     val pullToRefreshState = rememberPullToRefreshState()
-    val postInteractionSheetState = rememberUpdatedPostInteractionsSheetState(
-        isSignedIn = paneScaffoldState.isSignedIn,
+    val postInteractionSheetState = paneScaffoldState.rememberPostInteractionsSheetState(
         onSignInClicked = {
             actions(Action.Navigate.To(signInDestination()))
         },
@@ -161,7 +160,6 @@ private fun FeedTimeline(
             )
         },
     )
-
     val threadGateSheetState = paneScaffoldState.rememberTimelineThreadGateSheetState(
         onThreadGateUpdated = {
             actions(Action.SendPostInteraction(it))

--- a/feature/gallery/src/commonMain/kotlin/com/tunjid/heron/gallery/GalleryScreen.kt
+++ b/feature/gallery/src/commonMain/kotlin/com/tunjid/heron/gallery/GalleryScreen.kt
@@ -93,13 +93,13 @@ import com.tunjid.heron.scaffold.scaffold.DragToPopState.Companion.dragToPop
 import com.tunjid.heron.scaffold.scaffold.DragToPopState.Companion.rememberDragToPopState
 import com.tunjid.heron.scaffold.scaffold.PaneScaffoldState
 import com.tunjid.heron.scaffold.scaffold.rememberMutedWordsSheetState
+import com.tunjid.heron.scaffold.scaffold.rememberPostInteractionsSheetState
 import com.tunjid.heron.scaffold.scaffold.rememberPostOptionsSheetState
 import com.tunjid.heron.tiling.TilingState
 import com.tunjid.heron.tiling.tiledItems
 import com.tunjid.heron.timeline.state.TimelineState
-import com.tunjid.heron.timeline.ui.post.PostInteractionsSheetState
-import com.tunjid.heron.timeline.ui.post.PostInteractionsSheetState.Companion.rememberUpdatedPostInteractionsSheetState
 import com.tunjid.heron.timeline.ui.profile.ProfileRestrictionDialogState.Companion.rememberProfileRestrictionDialogState
+import com.tunjid.heron.timeline.ui.sheets.postinteractions.PostInteractionsSheetState
 import com.tunjid.heron.timeline.ui.sheets.postoptions.PostOption
 import com.tunjid.heron.timeline.ui.sheets.postoptions.PostOptionsSheetState
 import com.tunjid.heron.timeline.ui.sheets.postoptions.PostOptionsSheetState.Companion.rememberUpdatedPostOptionsSheetState
@@ -121,8 +121,7 @@ internal fun GalleryScreen(
     state: State,
     actions: (Action) -> Unit,
 ) {
-    val postInteractionSheetState = rememberUpdatedPostInteractionsSheetState(
-        isSignedIn = paneScaffoldState.isSignedIn,
+    val postInteractionSheetState = paneScaffoldState.rememberPostInteractionsSheetState(
         onSignInClicked = {
             actions(Action.Navigate.To(signInDestination()))
         },

--- a/feature/gallery/src/commonMain/kotlin/com/tunjid/heron/gallery/GalleryScreen.kt
+++ b/feature/gallery/src/commonMain/kotlin/com/tunjid/heron/gallery/GalleryScreen.kt
@@ -139,6 +139,7 @@ internal fun GalleryScreen(
             )
         },
     )
+
     val mutedWordsSheetState = paneScaffoldState.rememberMutedWordsSheetState()
 
     val profileRestrictionDialogState = rememberProfileRestrictionDialogState(

--- a/feature/gallery/src/commonMain/kotlin/com/tunjid/heron/gallery/ui/Comments.kt
+++ b/feature/gallery/src/commonMain/kotlin/com/tunjid/heron/gallery/ui/Comments.kt
@@ -92,10 +92,10 @@ import com.tunjid.heron.scaffold.navigation.recordDestination
 import com.tunjid.heron.scaffold.navigation.signInDestination
 import com.tunjid.heron.scaffold.scaffold.PaneFab
 import com.tunjid.heron.scaffold.scaffold.PaneScaffoldState
+import com.tunjid.heron.scaffold.scaffold.rememberPostInteractionsSheetState
 import com.tunjid.heron.timeline.ui.PostAction
 import com.tunjid.heron.timeline.ui.PostActions
 import com.tunjid.heron.timeline.ui.TimelineItem
-import com.tunjid.heron.timeline.ui.post.PostInteractionsSheetState.Companion.rememberUpdatedPostInteractionsSheetState
 import com.tunjid.heron.timeline.ui.sheets.postoptions.PostOptionsSheetState
 import com.tunjid.heron.timeline.ui.withQuotingPostUriPrefix
 import com.tunjid.heron.timeline.utilities.avatarSharedElementKey
@@ -196,8 +196,7 @@ fun Comments(
         val presentation = Timeline.Presentation.Text.WithEmbed
         val displayState = rememberTimelineDisplayState()
 
-        val postInteractionSheetState = rememberUpdatedPostInteractionsSheetState(
-            isSignedIn = paneScaffoldState.isSignedIn,
+        val postInteractionSheetState = paneScaffoldState.rememberPostInteractionsSheetState(
             onSignInClicked = {
                 actions(Action.Navigate.To(signInDestination()))
             },

--- a/feature/gallery/src/commonMain/kotlin/com/tunjid/heron/gallery/ui/Media.kt
+++ b/feature/gallery/src/commonMain/kotlin/com/tunjid/heron/gallery/ui/Media.kt
@@ -73,10 +73,10 @@ import com.tunjid.heron.scaffold.navigation.profileDestination
 import com.tunjid.heron.scaffold.scaffold.PaneScaffoldState
 import com.tunjid.heron.timeline.ui.PostAction
 import com.tunjid.heron.timeline.ui.post.MediaPostInteractions
-import com.tunjid.heron.timeline.ui.post.PostInteractionsSheetState
 import com.tunjid.heron.timeline.ui.post.PostText
 import com.tunjid.heron.timeline.ui.post.sharedElementKey
 import com.tunjid.heron.timeline.ui.profile.ProfileWithViewerState
+import com.tunjid.heron.timeline.ui.sheets.postinteractions.PostInteractionsSheetState
 import com.tunjid.heron.timeline.ui.sheets.postoptions.PostOptionsSheetState
 import com.tunjid.heron.timeline.utilities.avatarSharedElementKey
 import com.tunjid.heron.ui.ScrimmedContent

--- a/feature/graze-editor/src/commonMain/kotlin/com/tunjid/heron/graze/editor/ui/filter/SocialFilters.kt
+++ b/feature/graze-editor/src/commonMain/kotlin/com/tunjid/heron/graze/editor/ui/filter/SocialFilters.kt
@@ -32,7 +32,6 @@ import com.tunjid.heron.data.graze.Filter
 import com.tunjid.heron.scaffold.scaffold.PaneScaffoldState
 import com.tunjid.heron.scaffold.scaffold.rememberSelectListSheetState
 import com.tunjid.heron.timeline.ui.sheets.SelectTextSheetState.Companion.rememberSelectProfileHandleState
-import com.tunjid.mutator.compose.produceState
 import heron.feature.graze_editor.generated.resources.Res
 import heron.feature.graze_editor.generated.resources.add_profile
 import heron.feature.graze_editor.generated.resources.direction

--- a/feature/home/src/commonMain/kotlin/com/tunjid/heron/home/HomeScreen.kt
+++ b/feature/home/src/commonMain/kotlin/com/tunjid/heron/home/HomeScreen.kt
@@ -82,6 +82,7 @@ import com.tunjid.heron.scaffold.navigation.signInDestination
 import com.tunjid.heron.scaffold.scaffold.PaneScaffoldState
 import com.tunjid.heron.scaffold.scaffold.paneClip
 import com.tunjid.heron.scaffold.scaffold.rememberMutedWordsSheetState
+import com.tunjid.heron.scaffold.scaffold.rememberPostInteractionsSheetState
 import com.tunjid.heron.scaffold.scaffold.rememberPostOptionsSheetState
 import com.tunjid.heron.scaffold.scaffold.rememberTimelineThreadGateSheetState
 import com.tunjid.heron.tiling.TilingState
@@ -94,12 +95,10 @@ import com.tunjid.heron.timeline.ui.PostAction
 import com.tunjid.heron.timeline.ui.PostActions
 import com.tunjid.heron.timeline.ui.TimelineItem
 import com.tunjid.heron.timeline.ui.effects.TimelineRefreshEffect
-import com.tunjid.heron.timeline.ui.post.PostInteractionsSheetState.Companion.rememberUpdatedPostInteractionsSheetState
 import com.tunjid.heron.timeline.ui.post.threadtraversal.ThreadedVideoPositionState.Companion.threadedVideoPosition
 import com.tunjid.heron.timeline.ui.post.threadtraversal.ThreadedVideoPositionStates
 import com.tunjid.heron.timeline.ui.profile.ProfileRestrictionDialogState.Companion.rememberProfileRestrictionDialogState
 import com.tunjid.heron.timeline.ui.sheets.postoptions.PostOption
-import com.tunjid.heron.timeline.ui.sheets.threadgate.ThreadGateSheetState.Companion.rememberUpdatedThreadGateSheetState
 import com.tunjid.heron.timeline.utilities.avatarSharedElementKey
 import com.tunjid.heron.timeline.utilities.canAutoPlayVideo
 import com.tunjid.heron.timeline.utilities.contentType
@@ -317,8 +316,7 @@ private fun HomeTimeline(
     val presentation = timelineState.timeline.presentation
     val displayState = rememberTimelineDisplayState()
     val pullToRefreshState = rememberPullToRefreshState()
-    val postInteractionSheetState = rememberUpdatedPostInteractionsSheetState(
-        isSignedIn = paneScaffoldState.isSignedIn,
+    val postInteractionSheetState = paneScaffoldState.rememberPostInteractionsSheetState(
         onSignInClicked = {
             actions(Action.Navigate.To(signInDestination()))
         },

--- a/feature/list/src/commonMain/kotlin/com/tunjid/heron/list/ListScreen.kt
+++ b/feature/list/src/commonMain/kotlin/com/tunjid/heron/list/ListScreen.kt
@@ -84,6 +84,7 @@ import com.tunjid.heron.scaffold.navigation.signInDestination
 import com.tunjid.heron.scaffold.scaffold.PaneScaffoldState
 import com.tunjid.heron.scaffold.scaffold.paneClip
 import com.tunjid.heron.scaffold.scaffold.rememberMutedWordsSheetState
+import com.tunjid.heron.scaffold.scaffold.rememberPostInteractionsSheetState
 import com.tunjid.heron.scaffold.scaffold.rememberPostOptionsSheetState
 import com.tunjid.heron.scaffold.scaffold.rememberTimelineThreadGateSheetState
 import com.tunjid.heron.tiling.TilingState
@@ -95,7 +96,6 @@ import com.tunjid.heron.timeline.ui.PostAction
 import com.tunjid.heron.timeline.ui.PostActions
 import com.tunjid.heron.timeline.ui.TimelineItem
 import com.tunjid.heron.timeline.ui.effects.TimelineRefreshEffect
-import com.tunjid.heron.timeline.ui.post.PostInteractionsSheetState.Companion.rememberUpdatedPostInteractionsSheetState
 import com.tunjid.heron.timeline.ui.post.threadtraversal.ThreadedVideoPositionState.Companion.threadedVideoPosition
 import com.tunjid.heron.timeline.ui.post.threadtraversal.ThreadedVideoPositionStates
 import com.tunjid.heron.timeline.ui.profile.ProfileRestrictionDialogState.Companion.rememberProfileRestrictionDialogState
@@ -445,8 +445,7 @@ private fun ListTimeline(
     val videoStates = remember { ThreadedVideoPositionStates(TimelineItem::id) }
     val presentation = timelineState.timeline.presentation
     val displayState = rememberTimelineDisplayState()
-    val postInteractionSheetState = rememberUpdatedPostInteractionsSheetState(
-        isSignedIn = paneScaffoldState.isSignedIn,
+    val postInteractionSheetState = paneScaffoldState.rememberPostInteractionsSheetState(
         onSignInClicked = {
             actions(Action.Navigate.To(signInDestination()))
         },

--- a/feature/notifications/src/commonMain/kotlin/com/tunjid/heron/notifications/NotificationsScreen.kt
+++ b/feature/notifications/src/commonMain/kotlin/com/tunjid/heron/notifications/NotificationsScreen.kt
@@ -70,14 +70,13 @@ import com.tunjid.heron.scaffold.navigation.signInDestination
 import com.tunjid.heron.scaffold.scaffold.PaneScaffoldState
 import com.tunjid.heron.scaffold.scaffold.paneClip
 import com.tunjid.heron.scaffold.scaffold.rememberMutedWordsSheetState
+import com.tunjid.heron.scaffold.scaffold.rememberPostInteractionsSheetState
 import com.tunjid.heron.scaffold.scaffold.rememberPostOptionsSheetState
 import com.tunjid.heron.tiling.TilingState
 import com.tunjid.heron.tiling.isRefreshing
 import com.tunjid.heron.timeline.ui.PostAction
-import com.tunjid.heron.timeline.ui.post.PostInteractionsSheetState.Companion.rememberUpdatedPostInteractionsSheetState
 import com.tunjid.heron.timeline.ui.profile.ProfileRestrictionDialogState.Companion.rememberProfileRestrictionDialogState
 import com.tunjid.heron.timeline.ui.sheets.postoptions.PostOption
-import com.tunjid.heron.timeline.ui.sheets.postoptions.PostOptionsSheetState.Companion.rememberUpdatedPostOptionsSheetState
 import com.tunjid.heron.timeline.utilities.avatarSharedElementKey
 import com.tunjid.heron.ui.UiTokens
 import com.tunjid.heron.ui.UiTokens.bottomNavAndInsetPaddingValues
@@ -94,8 +93,7 @@ internal fun NotificationsScreen(
     actions: (Action) -> Unit,
 ) {
     val listState = rememberLazyListState()
-    val postInteractionSheetState = rememberUpdatedPostInteractionsSheetState(
-        isSignedIn = paneScaffoldState.isSignedIn,
+    val postInteractionSheetState = paneScaffoldState.rememberPostInteractionsSheetState(
         onSignInClicked = {
             actions(Action.Navigate.To(signInDestination()))
         },

--- a/feature/post-detail/src/commonMain/kotlin/com/tunjid/heron/postdetail/PostDetailScreen.kt
+++ b/feature/post-detail/src/commonMain/kotlin/com/tunjid/heron/postdetail/PostDetailScreen.kt
@@ -57,12 +57,12 @@ import com.tunjid.heron.scaffold.navigation.signInDestination
 import com.tunjid.heron.scaffold.scaffold.PaneScaffoldState
 import com.tunjid.heron.scaffold.scaffold.paneClip
 import com.tunjid.heron.scaffold.scaffold.rememberMutedWordsSheetState
+import com.tunjid.heron.scaffold.scaffold.rememberPostInteractionsSheetState
 import com.tunjid.heron.scaffold.scaffold.rememberPostOptionsSheetState
 import com.tunjid.heron.scaffold.scaffold.rememberTimelineThreadGateSheetState
 import com.tunjid.heron.timeline.ui.PostAction
 import com.tunjid.heron.timeline.ui.PostActions
 import com.tunjid.heron.timeline.ui.TimelineItem
-import com.tunjid.heron.timeline.ui.post.PostInteractionsSheetState.Companion.rememberUpdatedPostInteractionsSheetState
 import com.tunjid.heron.timeline.ui.post.PostMetadata
 import com.tunjid.heron.timeline.ui.post.threadtraversal.ThreadedVideoPositionState.Companion.threadedVideoPosition
 import com.tunjid.heron.timeline.ui.post.threadtraversal.ThreadedVideoPositionStates
@@ -98,8 +98,7 @@ internal fun PostDetailScreen(
             actions(Action.Navigate.To(destination))
         }
     }
-    val postInteractionSheetState = rememberUpdatedPostInteractionsSheetState(
-        isSignedIn = paneScaffoldState.isSignedIn,
+    val postInteractionSheetState = paneScaffoldState.rememberPostInteractionsSheetState(
         onSignInClicked = {
             actions(Action.Navigate.To(signInDestination()))
         },

--- a/feature/posts/src/commonMain/kotlin/com/tunjid/heron/posts/PostsScreen.kt
+++ b/feature/posts/src/commonMain/kotlin/com/tunjid/heron/posts/PostsScreen.kt
@@ -56,6 +56,7 @@ import com.tunjid.heron.scaffold.navigation.recordDestination
 import com.tunjid.heron.scaffold.navigation.signInDestination
 import com.tunjid.heron.scaffold.scaffold.PaneScaffoldState
 import com.tunjid.heron.scaffold.scaffold.rememberMutedWordsSheetState
+import com.tunjid.heron.scaffold.scaffold.rememberPostInteractionsSheetState
 import com.tunjid.heron.scaffold.scaffold.rememberPostOptionsSheetState
 import com.tunjid.heron.scaffold.scaffold.rememberTimelineThreadGateSheetState
 import com.tunjid.heron.tiling.TilingState
@@ -64,12 +65,10 @@ import com.tunjid.heron.timeline.ui.DismissableRefreshIndicator
 import com.tunjid.heron.timeline.ui.PostAction
 import com.tunjid.heron.timeline.ui.PostActions
 import com.tunjid.heron.timeline.ui.TimelineItem
-import com.tunjid.heron.timeline.ui.post.PostInteractionsSheetState.Companion.rememberUpdatedPostInteractionsSheetState
 import com.tunjid.heron.timeline.ui.post.threadtraversal.ThreadedVideoPositionState.Companion.threadedVideoPosition
 import com.tunjid.heron.timeline.ui.post.threadtraversal.ThreadedVideoPositionStates
 import com.tunjid.heron.timeline.ui.profile.ProfileRestrictionDialogState.Companion.rememberProfileRestrictionDialogState
 import com.tunjid.heron.timeline.ui.sheets.postoptions.PostOption
-import com.tunjid.heron.timeline.ui.sheets.threadgate.ThreadGateSheetState.Companion.rememberUpdatedThreadGateSheetState
 import com.tunjid.heron.timeline.ui.withQuotingPostUriPrefix
 import com.tunjid.heron.timeline.utilities.avatarSharedElementKey
 import com.tunjid.heron.timeline.utilities.canAutoPlayVideo
@@ -95,8 +94,7 @@ internal fun PostsScreen(
     val presentation = remember { Timeline.Presentation.Text.WithEmbed }
     val displayState = rememberTimelineDisplayState()
     val pullToRefreshState = rememberPullToRefreshState()
-    val postInteractionSheetState = rememberUpdatedPostInteractionsSheetState(
-        isSignedIn = paneScaffoldState.isSignedIn,
+    val postInteractionSheetState = paneScaffoldState.rememberPostInteractionsSheetState(
         onSignInClicked = {
             actions(Action.Navigate.To(signInDestination()))
         },
@@ -114,6 +112,7 @@ internal fun PostsScreen(
             )
         },
     )
+
     val threadGateSheetState = paneScaffoldState.rememberTimelineThreadGateSheetState(
         onThreadGateUpdated = {
             actions(Action.SendPostInteraction(it))

--- a/feature/profile/src/commonMain/kotlin/com/tunjid/heron/profile/ProfileScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/tunjid/heron/profile/ProfileScreen.kt
@@ -139,6 +139,7 @@ import com.tunjid.heron.scaffold.scaffold.PaneScaffoldState
 import com.tunjid.heron.scaffold.scaffold.SignInPopUpState.Companion.rememberSignInPopUpState
 import com.tunjid.heron.scaffold.scaffold.paneClip
 import com.tunjid.heron.scaffold.scaffold.rememberMutedWordsSheetState
+import com.tunjid.heron.scaffold.scaffold.rememberPostInteractionsSheetState
 import com.tunjid.heron.scaffold.scaffold.rememberPostOptionsSheetState
 import com.tunjid.heron.scaffold.scaffold.rememberTimelineThreadGateSheetState
 import com.tunjid.heron.tiling.TilingState
@@ -153,7 +154,6 @@ import com.tunjid.heron.timeline.ui.effects.TimelineRefreshEffect
 import com.tunjid.heron.timeline.ui.feed.FeedGenerator
 import com.tunjid.heron.timeline.ui.list.FeedList
 import com.tunjid.heron.timeline.ui.list.StarterPack
-import com.tunjid.heron.timeline.ui.post.PostInteractionsSheetState.Companion.rememberUpdatedPostInteractionsSheetState
 import com.tunjid.heron.timeline.ui.post.threadtraversal.ThreadedVideoPositionState.Companion.threadedVideoPosition
 import com.tunjid.heron.timeline.ui.post.threadtraversal.ThreadedVideoPositionStates
 import com.tunjid.heron.timeline.ui.profile.ProfileHandle
@@ -1353,8 +1353,7 @@ private fun ProfileTimeline(
     val videoStates = remember { ThreadedVideoPositionStates(TimelineItem::id) }
     val presentation = timelineState.timeline.presentation
     val displayState = rememberTimelineDisplayState()
-    val postInteractionSheetState = rememberUpdatedPostInteractionsSheetState(
-        isSignedIn = paneScaffoldState.isSignedIn,
+    val postInteractionSheetState = paneScaffoldState.rememberPostInteractionsSheetState(
         onSignInClicked = {
             actions(Action.Navigate.To(signInDestination()))
         },

--- a/feature/profile/src/commonMain/kotlin/com/tunjid/heron/profile/ProfileScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/tunjid/heron/profile/ProfileScreen.kt
@@ -1371,6 +1371,7 @@ private fun ProfileTimeline(
             )
         },
     )
+
     val threadGateSheetState = paneScaffoldState.rememberTimelineThreadGateSheetState(
         onThreadGateUpdated = {
             actions(Action.SendPostInteraction(it))

--- a/feature/search/src/commonMain/kotlin/com/tunjid/heron/search/ui/searchresults/PostSearchResults.kt
+++ b/feature/search/src/commonMain/kotlin/com/tunjid/heron/search/ui/searchresults/PostSearchResults.kt
@@ -51,6 +51,7 @@ import com.tunjid.heron.scaffold.navigation.conversationDestination
 import com.tunjid.heron.scaffold.navigation.signInDestination
 import com.tunjid.heron.scaffold.scaffold.PaneScaffoldState
 import com.tunjid.heron.scaffold.scaffold.rememberMutedWordsSheetState
+import com.tunjid.heron.scaffold.scaffold.rememberPostInteractionsSheetState
 import com.tunjid.heron.scaffold.scaffold.rememberPostOptionsSheetState
 import com.tunjid.heron.scaffold.scaffold.rememberTimelineThreadGateSheetState
 import com.tunjid.heron.search.SearchResult
@@ -63,7 +64,6 @@ import com.tunjid.heron.tiling.tiledItems
 import com.tunjid.heron.timeline.ui.PostAction
 import com.tunjid.heron.timeline.ui.PostActions
 import com.tunjid.heron.timeline.ui.TimelineItem
-import com.tunjid.heron.timeline.ui.post.PostInteractionsSheetState.Companion.rememberUpdatedPostInteractionsSheetState
 import com.tunjid.heron.timeline.ui.post.threadtraversal.ThreadedVideoPositionState.Companion.threadedVideoPosition
 import com.tunjid.heron.timeline.ui.post.threadtraversal.ThreadedVideoPositionStates
 import com.tunjid.heron.timeline.ui.profile.ProfileRestrictionDialogState.Companion.rememberProfileRestrictionDialogState
@@ -109,8 +109,7 @@ internal fun PostSearchResults(
     val displayState = rememberTimelineDisplayState()
     val results by rememberUpdatedState(state.tiledItems)
     val sharedElementPrefix = state.sharedElementPrefix
-    val postInteractionSheetState = rememberUpdatedPostInteractionsSheetState(
-        isSignedIn = paneScaffoldState.isSignedIn,
+    val postInteractionSheetState = paneScaffoldState.rememberPostInteractionsSheetState(
         onSignInClicked = {
             onNavigate(signInDestination())
         },

--- a/feature/search/src/commonMain/kotlin/com/tunjid/heron/search/ui/searchresults/PostSearchResults.kt
+++ b/feature/search/src/commonMain/kotlin/com/tunjid/heron/search/ui/searchresults/PostSearchResults.kt
@@ -68,7 +68,6 @@ import com.tunjid.heron.timeline.ui.post.threadtraversal.ThreadedVideoPositionSt
 import com.tunjid.heron.timeline.ui.post.threadtraversal.ThreadedVideoPositionStates
 import com.tunjid.heron.timeline.ui.profile.ProfileRestrictionDialogState.Companion.rememberProfileRestrictionDialogState
 import com.tunjid.heron.timeline.ui.sheets.postoptions.PostOption
-import com.tunjid.heron.timeline.ui.sheets.threadgate.ThreadGateSheetState.Companion.rememberUpdatedThreadGateSheetState
 import com.tunjid.heron.timeline.ui.withQuotingPostUriPrefix
 import com.tunjid.heron.timeline.utilities.rememberTimelineDisplayState
 import com.tunjid.heron.ui.PaneTransitionScope

--- a/scaffold/src/commonMain/kotlin/com/tunjid/heron/scaffold/scaffold/PaneSheets.kt
+++ b/scaffold/src/commonMain/kotlin/com/tunjid/heron/scaffold/scaffold/PaneSheets.kt
@@ -8,6 +8,7 @@ import com.tunjid.heron.data.core.models.PostInteractionSettingsPreference
 import com.tunjid.heron.data.core.types.EmbeddableRecordUri
 import com.tunjid.heron.timeline.ui.sheets.embedrecordoptions.EmbeddableRecordOptionsSheetState
 import com.tunjid.heron.timeline.ui.sheets.mutedwords.MutedWordsSheetState
+import com.tunjid.heron.timeline.ui.sheets.postinteractions.PostInteractionsSheetState
 import com.tunjid.heron.timeline.ui.sheets.postoptions.PostOption
 import com.tunjid.heron.timeline.ui.sheets.postoptions.PostOptionsSheetState
 import com.tunjid.heron.timeline.ui.sheets.selectlist.SelectListSheetState
@@ -68,4 +69,17 @@ fun PaneScaffoldState.rememberSelectListSheetState(
     SelectListSheetState.rememberUpdatedSelectListSheetState(
         initializer = appState.sheetsViewModelInitializers.selectListViewModelInitializer,
         onListSelected = onListSelected,
+    )
+
+@Composable
+fun PaneScaffoldState.rememberPostInteractionsSheetState(
+    onSignInClicked: () -> Unit,
+    onInteractionConfirmed: (Post.Interaction) -> Unit,
+    onQuotePostClicked: (Post.Interaction.Create.Repost) -> Unit,
+): PostInteractionsSheetState =
+    PostInteractionsSheetState.rememberUpdatedPostInteractionsSheetState(
+        initializer = appState.sheetsViewModelInitializers.postInteractionsViewModelInitializer,
+        onSignInClicked = onSignInClicked,
+        onInteractionConfirmed = onInteractionConfirmed,
+        onQuotePostClicked = onQuotePostClicked,
     )

--- a/scaffold/src/commonMain/kotlin/com/tunjid/heron/scaffold/scaffold/PaneSheets.kt
+++ b/scaffold/src/commonMain/kotlin/com/tunjid/heron/scaffold/scaffold/PaneSheets.kt
@@ -2,6 +2,7 @@ package com.tunjid.heron.scaffold.scaffold
 
 import androidx.compose.runtime.Composable
 import com.tunjid.heron.data.core.models.Conversation
+import com.tunjid.heron.data.core.models.FeedList
 import com.tunjid.heron.data.core.models.Post
 import com.tunjid.heron.data.core.models.PostInteractionSettingsPreference
 import com.tunjid.heron.data.core.types.EmbeddableRecordUri
@@ -10,6 +11,7 @@ import com.tunjid.heron.timeline.ui.sheets.mutedwords.MutedWordsSheetState
 import com.tunjid.heron.timeline.ui.sheets.postinteractions.PostInteractionsSheetState
 import com.tunjid.heron.timeline.ui.sheets.postoptions.PostOption
 import com.tunjid.heron.timeline.ui.sheets.postoptions.PostOptionsSheetState
+import com.tunjid.heron.timeline.ui.sheets.selectlist.SelectListSheetState
 import com.tunjid.heron.timeline.ui.sheets.threadgate.ThreadGateSheetState
 
 @Composable
@@ -58,6 +60,15 @@ fun PaneScaffoldState.rememberEmbeddableRecordOptionsSheetState(
         onEditClicked = onEditClicked,
         onShareInConversationClicked = onShareInConversationClicked,
         onShareInPostClicked = onShareInPostClicked,
+    )
+
+@Composable
+fun PaneScaffoldState.rememberSelectListSheetState(
+    onListSelected: (FeedList) -> Unit,
+): SelectListSheetState =
+    SelectListSheetState.rememberUpdatedSelectListSheetState(
+        initializer = appState.sheetsViewModelInitializers.selectListViewModelInitializer,
+        onListSelected = onListSelected,
     )
 
 @Composable

--- a/scaffold/src/commonMain/kotlin/com/tunjid/heron/scaffold/scaffold/PaneSheets.kt
+++ b/scaffold/src/commonMain/kotlin/com/tunjid/heron/scaffold/scaffold/PaneSheets.kt
@@ -2,7 +2,6 @@ package com.tunjid.heron.scaffold.scaffold
 
 import androidx.compose.runtime.Composable
 import com.tunjid.heron.data.core.models.Conversation
-import com.tunjid.heron.data.core.models.FeedList
 import com.tunjid.heron.data.core.models.Post
 import com.tunjid.heron.data.core.models.PostInteractionSettingsPreference
 import com.tunjid.heron.data.core.types.EmbeddableRecordUri
@@ -11,7 +10,6 @@ import com.tunjid.heron.timeline.ui.sheets.mutedwords.MutedWordsSheetState
 import com.tunjid.heron.timeline.ui.sheets.postinteractions.PostInteractionsSheetState
 import com.tunjid.heron.timeline.ui.sheets.postoptions.PostOption
 import com.tunjid.heron.timeline.ui.sheets.postoptions.PostOptionsSheetState
-import com.tunjid.heron.timeline.ui.sheets.selectlist.SelectListSheetState
 import com.tunjid.heron.timeline.ui.sheets.threadgate.ThreadGateSheetState
 
 @Composable
@@ -60,15 +58,6 @@ fun PaneScaffoldState.rememberEmbeddableRecordOptionsSheetState(
         onEditClicked = onEditClicked,
         onShareInConversationClicked = onShareInConversationClicked,
         onShareInPostClicked = onShareInPostClicked,
-    )
-
-@Composable
-fun PaneScaffoldState.rememberSelectListSheetState(
-    onListSelected: (FeedList) -> Unit,
-): SelectListSheetState =
-    SelectListSheetState.rememberUpdatedSelectListSheetState(
-        initializer = appState.sheetsViewModelInitializers.selectListViewModelInitializer,
-        onListSelected = onListSelected,
     )
 
 @Composable

--- a/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/di/Bindings.kt
+++ b/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/di/Bindings.kt
@@ -19,6 +19,7 @@ package com.tunjid.heron.timeline.di
 import com.tunjid.heron.data.di.DataBindings
 import com.tunjid.heron.timeline.ui.sheets.embedrecordoptions.EmbeddableRecordOptionsViewModelInitializer
 import com.tunjid.heron.timeline.ui.sheets.mutedwords.MutedWordsViewModelInitializer
+import com.tunjid.heron.timeline.ui.sheets.postinteractions.PostInteractionsViewModelInitializer
 import com.tunjid.heron.timeline.ui.sheets.postoptions.PostOptionsViewModelInitializer
 import com.tunjid.heron.timeline.ui.sheets.selectlist.SelectListViewModelInitializer
 import com.tunjid.heron.timeline.ui.sheets.threadgate.ThreadGateViewModelInitializer
@@ -38,11 +39,13 @@ class SheetBindings(
         threadGateViewModelInitializer: ThreadGateViewModelInitializer,
         embeddableRecordOptionsViewModelInitializer: EmbeddableRecordOptionsViewModelInitializer,
         selectListViewModelInitializer: SelectListViewModelInitializer,
+        postInteractionsViewModelInitializer: PostInteractionsViewModelInitializer,
     ): SheetsViewModelInitializers = SheetsViewModelInitializers(
         mutedWordsViewModelInitializer = mutedWordsViewModelInitializer,
         postOptionsViewModelInitializer = postOptionsViewModelInitializer,
         threadGateViewModelInitializer = threadGateViewModelInitializer,
         embeddableRecordOptionsViewModelInitializer = embeddableRecordOptionsViewModelInitializer,
         selectListViewModelInitializer = selectListViewModelInitializer,
+        postInteractionsViewModelInitializer = postInteractionsViewModelInitializer,
     )
 }

--- a/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/ui/post/PostInteractions.kt
+++ b/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/ui/post/PostInteractions.kt
@@ -33,10 +33,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.text.TextAutoSize
 import androidx.compose.material.icons.Icons
@@ -46,33 +44,19 @@ import androidx.compose.material.icons.rounded.BookmarkBorder
 import androidx.compose.material.icons.rounded.ChatBubbleOutline
 import androidx.compose.material.icons.rounded.Favorite
 import androidx.compose.material.icons.rounded.FavoriteBorder
-import androidx.compose.material.icons.rounded.FormatQuote
 import androidx.compose.material.icons.rounded.Repeat
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.Text
 import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.Stable
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.capitalize
-import androidx.compose.ui.text.intl.Locale
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
@@ -80,7 +64,6 @@ import androidx.compose.ui.unit.sp
 import com.tunjid.composables.ui.animate
 import com.tunjid.heron.data.core.models.Post
 import com.tunjid.heron.data.core.models.Timeline
-import com.tunjid.heron.data.core.models.canQuote
 import com.tunjid.heron.data.core.models.canReply
 import com.tunjid.heron.data.core.models.isBookmarked
 import com.tunjid.heron.data.core.types.PostId
@@ -100,19 +83,10 @@ import com.tunjid.heron.ui.UiTokens.LikeRed
 import com.tunjid.heron.ui.UiTokens.RepostGreen
 import com.tunjid.heron.ui.UiTokens.withDim
 import com.tunjid.heron.ui.rememberLatchedState
-import com.tunjid.heron.ui.sheets.BottomSheetScope
-import com.tunjid.heron.ui.sheets.BottomSheetScope.Companion.ModalBottomSheet
-import com.tunjid.heron.ui.sheets.BottomSheetScope.Companion.rememberBottomSheetState
-import com.tunjid.heron.ui.sheets.BottomSheetState
-import com.tunjid.heron.ui.text.CommonStrings
-import heron.ui.core.generated.resources.cancel
-import heron.ui.core.generated.resources.sign_in
 import heron.ui.timeline.generated.resources.Res
 import heron.ui.timeline.generated.resources.bookmarked
 import heron.ui.timeline.generated.resources.expand_options
 import heron.ui.timeline.generated.resources.liked
-import heron.ui.timeline.generated.resources.quote
-import heron.ui.timeline.generated.resources.remove_repost
 import heron.ui.timeline.generated.resources.reply
 import heron.ui.timeline.generated.resources.repost
 import org.jetbrains.compose.resources.stringResource
@@ -453,201 +427,6 @@ private fun PostInteractionElements(
             animatable.animateTo(PostInteractionButton.BUTTON_MIN_SCALE)
         }
     }
-}
-
-@Stable
-class PostInteractionsSheetState private constructor(
-    isSignedIn: Boolean,
-    scope: BottomSheetScope,
-) : BottomSheetState(scope) {
-    internal var showingAction by mutableStateOf<PostAction.OfInteraction?>(null)
-
-    internal var isSignedIn by mutableStateOf(isSignedIn)
-
-    fun onInteraction(
-        interaction: PostAction.OfInteraction,
-    ) {
-        showingAction = interaction
-    }
-
-    override fun onHidden() {
-        showingAction = null
-    }
-
-    companion object {
-        @Composable
-        fun rememberUpdatedPostInteractionsSheetState(
-            isSignedIn: Boolean,
-            onSignInClicked: () -> Unit,
-            onInteractionConfirmed: (Post.Interaction) -> Unit,
-            // TODO: This should just be an interaction, however the interaction
-            //  is serialized, preventing changing its signature. This should be
-            //  fixed and migrated gracefully when able
-            onQuotePostClicked: (Post.Interaction.Create.Repost) -> Unit,
-        ): PostInteractionsSheetState {
-            val state = rememberBottomSheetState {
-                PostInteractionsSheetState(
-                    isSignedIn = isSignedIn,
-                    scope = it,
-                )
-            }.also { it.isSignedIn = isSignedIn }
-
-            PostInteractionsBottomSheet(
-                state = state,
-                onSignInClicked = onSignInClicked,
-                onInteractionConfirmed = onInteractionConfirmed,
-                onQuotePostClicked = onQuotePostClicked,
-            )
-
-            return state
-        }
-    }
-}
-
-@Composable
-private fun PostInteractionsBottomSheet(
-    state: PostInteractionsSheetState,
-    onSignInClicked: () -> Unit,
-    onInteractionConfirmed: (Post.Interaction) -> Unit,
-    onQuotePostClicked: (Post.Interaction.Create.Repost) -> Unit,
-) {
-    LaunchedEffect(state.showingAction) {
-        when (val interaction = state.showingAction?.interaction) {
-            null -> Unit
-            is Post.Interaction.Create.Repost,
-            is Post.Interaction.Delete.RemoveRepost,
-            -> state.show()
-            is Post.Interaction.Create.Like,
-            is Post.Interaction.Delete.Unlike,
-            is Post.Interaction.Create.Bookmark,
-            is Post.Interaction.Delete.RemoveBookmark,
-            is Post.Interaction.Upsert.Gate,
-            -> {
-                if (state.isSignedIn) {
-                    onInteractionConfirmed(interaction)
-                    state.showingAction = null
-                } else {
-                    state.show()
-                }
-            }
-        }
-    }
-
-    state.ModalBottomSheet {
-        val action = state.showingAction
-        val currentInteraction = action?.interaction
-        Column(
-            modifier = Modifier
-                .padding(horizontal = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            if (state.isSignedIn) {
-                when (currentInteraction) {
-                    is Post.Interaction.Create.Repost,
-                    is Post.Interaction.Delete.RemoveRepost,
-                    -> {
-                        Item(
-                            contentDescription = stringResource(
-                                if (currentInteraction is Post.Interaction.Create.Repost) Res.string.repost
-                                else Res.string.remove_repost,
-                            ),
-                            enabled = true,
-                            icon = Icons.Rounded.Repeat,
-                            onClick = {
-                                onInteractionConfirmed(currentInteraction)
-                                state.hide()
-                            },
-                        )
-                        Item(
-                            contentDescription = stringResource(Res.string.quote),
-                            enabled = action.viewerStats.canQuote,
-                            icon = Icons.Rounded.FormatQuote,
-                            onClick = {
-                                // TODO: Noted in the above, the only valuable part in the
-                                //  interaction is the PostUri weh removing a repost.
-                                //  Stubbing the PostId until a proper migration can be done.
-                                onQuotePostClicked(
-                                    Post.Interaction.Create.Repost(
-                                        postUri = currentInteraction.postUri,
-                                        postId = if (currentInteraction is Post.Interaction.Create.Repost) currentInteraction.postId
-                                        else PostId(""),
-                                    ),
-                                )
-                                state.hide()
-                            },
-                        )
-                    }
-
-                    else -> Unit
-                }
-            }
-
-            // Sheet content
-            OutlinedButton(
-                modifier = Modifier
-                    .fillMaxWidth(),
-                onClick = {
-                    if (!state.isSignedIn) onSignInClicked()
-                    state.hide()
-                },
-                content = {
-                    Text(
-                        text = stringResource(
-                            if (state.isSignedIn) CommonStrings.cancel
-                            else CommonStrings.sign_in,
-                        ),
-                        style = MaterialTheme.typography.bodyLarge,
-                    )
-                },
-            )
-            Spacer(
-                Modifier.height(16.dp),
-            )
-        }
-    }
-}
-
-@Composable
-private fun Item(
-    contentDescription: String,
-    enabled: Boolean,
-    icon: ImageVector,
-    onClick: () -> Unit,
-) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clip(CircleShape)
-            .then(
-                when {
-                    enabled -> Modifier.clickable(onClick = onClick)
-                    else -> Modifier.alpha(0.6f)
-                },
-            )
-            .padding(
-                horizontal = 8.dp,
-                vertical = 8.dp,
-            )
-            .semantics {
-                this.contentDescription = contentDescription
-            },
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        content = {
-            Icon(
-                modifier = Modifier
-                    .size(24.dp),
-                imageVector = icon,
-                contentDescription = null,
-            )
-            Text(
-                modifier = Modifier,
-                text = contentDescription
-                    .capitalize(locale = Locale.current),
-                style = MaterialTheme.typography.bodyLarge,
-            )
-        },
-    )
 }
 
 private val Timeline.Presentation.postInteractionArrangement: Arrangement.Horizontal

--- a/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/ui/sheets/postinteractions/PostInteractionsSheetState.kt
+++ b/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/ui/sheets/postinteractions/PostInteractionsSheetState.kt
@@ -52,7 +52,7 @@ import heron.ui.timeline.generated.resources.repost
 import org.jetbrains.compose.resources.stringResource
 
 @Stable
-class PostInteractionsSheetState(
+class PostInteractionsSheetState internal constructor(
     scope: BottomSheetScope,
     internal val viewModel: PostInteractionsViewModel,
 ) : BottomSheetState(scope) {

--- a/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/ui/sheets/postinteractions/PostInteractionsSheetState.kt
+++ b/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/ui/sheets/postinteractions/PostInteractionsSheetState.kt
@@ -1,0 +1,237 @@
+package com.tunjid.heron.timeline.ui.sheets.postinteractions
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.FormatQuote
+import androidx.compose.material.icons.rounded.Repeat
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.capitalize
+import androidx.compose.ui.text.intl.Locale
+import androidx.compose.ui.unit.dp
+import com.tunjid.heron.data.core.models.Post
+import com.tunjid.heron.data.core.models.canQuote
+import com.tunjid.heron.data.core.types.PostId
+import com.tunjid.heron.timeline.ui.PostAction
+import com.tunjid.heron.ui.sheets.BottomSheetScope
+import com.tunjid.heron.ui.sheets.BottomSheetScope.Companion.ModalBottomSheet
+import com.tunjid.heron.ui.sheets.BottomSheetScope.Companion.rememberBottomSheetState
+import com.tunjid.heron.ui.sheets.BottomSheetState
+import com.tunjid.heron.ui.text.CommonStrings
+import com.tunjid.mutator.compose.produceState
+import heron.ui.core.generated.resources.cancel
+import heron.ui.core.generated.resources.sign_in
+import heron.ui.timeline.generated.resources.Res
+import heron.ui.timeline.generated.resources.quote
+import heron.ui.timeline.generated.resources.remove_repost
+import heron.ui.timeline.generated.resources.repost
+import org.jetbrains.compose.resources.stringResource
+
+@Stable
+class PostInteractionsSheetState(
+    scope: BottomSheetScope,
+    internal val viewModel: PostInteractionsViewModel,
+) : BottomSheetState(scope) {
+
+    var showingAction by mutableStateOf<PostAction.OfInteraction?>(null)
+        internal set
+
+    val state: PostInteractionsState get() = viewModel.state
+
+    fun onInteraction(interaction: PostAction.OfInteraction) {
+        showingAction = interaction
+    }
+
+    override fun onHidden() {
+        showingAction = null
+    }
+
+    companion object {
+        @Composable
+        fun rememberUpdatedPostInteractionsSheetState(
+            initializer: PostInteractionsViewModelInitializer,
+            onSignInClicked: () -> Unit,
+            onInteractionConfirmed: (Post.Interaction) -> Unit,
+            onQuotePostClicked: (Post.Interaction.Create.Repost) -> Unit,
+        ): PostInteractionsSheetState {
+            val state = rememberBottomSheetState(
+                viewModelInitializer = initializer::invoke,
+                block = ::PostInteractionsSheetState,
+            )
+
+            PostInteractionsBottomSheet(
+                state = state,
+                onSignInClicked = onSignInClicked,
+                onInteractionConfirmed = onInteractionConfirmed,
+                onQuotePostClicked = onQuotePostClicked,
+            )
+
+            return state
+        }
+    }
+}
+
+@Composable
+private fun PostInteractionsBottomSheet(
+    state: PostInteractionsSheetState,
+    onSignInClicked: () -> Unit,
+    onInteractionConfirmed: (Post.Interaction) -> Unit,
+    onQuotePostClicked: (Post.Interaction.Create.Repost) -> Unit,
+) {
+    LaunchedEffect(state.showingAction) {
+        when (val interaction = state.showingAction?.interaction) {
+            null -> Unit
+            is Post.Interaction.Create.Repost,
+            is Post.Interaction.Delete.RemoveRepost,
+            -> state.show()
+            is Post.Interaction.Create.Like,
+            is Post.Interaction.Delete.Unlike,
+            is Post.Interaction.Create.Bookmark,
+            is Post.Interaction.Delete.RemoveBookmark,
+            is Post.Interaction.Upsert.Gate,
+            -> {
+                if (state.state.isSignedIn) {
+                    onInteractionConfirmed(interaction)
+                    state.showingAction = null
+                } else {
+                    state.show()
+                }
+            }
+        }
+    }
+
+    state.ModalBottomSheet {
+        val postInteractionsState = state.viewModel.produceState()
+        val action = state.showingAction
+        val currentInteraction = action?.interaction
+
+        Column(
+            modifier = Modifier.padding(horizontal = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            if (postInteractionsState.isSignedIn) {
+                when (currentInteraction) {
+                    is Post.Interaction.Create.Repost,
+                    is Post.Interaction.Delete.RemoveRepost,
+                    -> {
+                        Item(
+                            contentDescription = stringResource(
+                                if (currentInteraction is Post.Interaction.Create.Repost)
+                                    Res.string.repost
+                                else Res.string.remove_repost,
+                            ),
+                            enabled = true,
+                            icon = Icons.Rounded.Repeat,
+                            onClick = {
+                                onInteractionConfirmed(currentInteraction)
+                                state.hide()
+                            },
+                        )
+                        Item(
+                            contentDescription = stringResource(Res.string.quote),
+                            enabled = action.viewerStats.canQuote,
+                            icon = Icons.Rounded.FormatQuote,
+                            onClick = {
+                                onQuotePostClicked(
+                                    Post.Interaction.Create.Repost(
+                                        postUri = currentInteraction.postUri,
+                                        postId = if (currentInteraction is Post.Interaction.Create.Repost)
+                                            currentInteraction.postId
+                                        else PostId(""),
+                                    ),
+                                )
+                                state.hide()
+                            },
+                        )
+                    }
+                    else -> Unit
+                }
+            }
+
+            OutlinedButton(
+                modifier = Modifier.fillMaxWidth(),
+                onClick = {
+                    if (!postInteractionsState.isSignedIn) onSignInClicked()
+                    state.hide()
+                },
+                content = {
+                    Text(
+                        text = stringResource(
+                            if (postInteractionsState.isSignedIn) CommonStrings.cancel
+                            else CommonStrings.sign_in,
+                        ),
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                },
+            )
+            Spacer(Modifier.height(16.dp))
+        }
+    }
+}
+
+@Composable
+private fun Item(
+    contentDescription: String,
+    enabled: Boolean,
+    icon: ImageVector,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(CircleShape)
+            .then(
+                when {
+                    enabled -> Modifier.clickable(onClick = onClick)
+                    else -> Modifier.alpha(0.6f)
+                },
+            )
+            .padding(
+                horizontal = 8.dp,
+                vertical = 8.dp,
+            )
+            .semantics {
+                this.contentDescription = contentDescription
+            },
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        content = {
+            Icon(
+                modifier = Modifier
+                    .size(24.dp),
+                imageVector = icon,
+                contentDescription = null,
+            )
+            Text(
+                modifier = Modifier,
+                text = contentDescription
+                    .capitalize(locale = Locale.current),
+                style = MaterialTheme.typography.bodyLarge,
+            )
+        },
+    )
+}

--- a/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/ui/sheets/postinteractions/PostInteractionsStateHolder.kt
+++ b/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/ui/sheets/postinteractions/PostInteractionsStateHolder.kt
@@ -1,0 +1,67 @@
+package com.tunjid.heron.timeline.ui.sheets.postinteractions
+
+import androidx.compose.runtime.Stable
+import androidx.lifecycle.ViewModel
+import com.tunjid.heron.data.repository.AuthRepository
+import com.tunjid.heron.timeline.ui.sheets.postoptions.PostOptionsState
+import com.tunjid.heron.timeline.utilities.SheetWhileSubscribed
+import com.tunjid.mutator.coroutines.ActionSuspendingStateMutator
+import com.tunjid.mutator.coroutines.actionSuspendingStateMutator
+import com.tunjid.mutator.coroutines.launchedCollect
+import com.tunjid.snapshottable.SnapshotSpec
+import com.tunjid.snapshottable.Snapshottable
+import dev.zacsweers.metro.Assisted
+import dev.zacsweers.metro.AssistedFactory
+import dev.zacsweers.metro.AssistedInject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.serialization.Serializable
+
+typealias PostInteractionsStateHolder =
+    ActionSuspendingStateMutator<PostInteractionsAction, PostInteractionsState>
+
+@AssistedFactory
+fun interface PostInteractionsViewModelInitializer {
+    fun invoke(
+        scope: CoroutineScope,
+    ): PostInteractionsViewModel
+}
+
+@AssistedInject
+class PostInteractionsViewModel(
+    authRepository: AuthRepository,
+    @Assisted scope: CoroutineScope,
+) : ViewModel(viewModelScope = scope),
+    PostInteractionsStateHolder by scope.actionSuspendingStateMutator(
+        state = PostInteractionsState.Immutable().toSnapshotMutable(),
+        started = SharingStarted.WhileSubscribed(SheetWhileSubscribed),
+        producer = { state, _ ->
+            launchLoadSignedInMutations(
+                state = state,
+                authRepository = authRepository,
+            )
+        },
+    )
+
+context(productionScope: CoroutineScope)
+private fun launchLoadSignedInMutations(
+    state: PostInteractionsState.SnapshotMutable,
+    authRepository: AuthRepository,
+) = authRepository.signedInUser
+    .distinctUntilChanged()
+    .launchedCollect {
+        state.isSignedIn = it != null
+    }
+
+@Stable
+@Snapshottable
+interface PostInteractionsState {
+    @SnapshotSpec
+    @Serializable
+    data class Immutable(
+        val isSignedIn: Boolean = false,
+    ) : PostInteractionsState
+}
+
+sealed class PostInteractionsAction(val key: String)

--- a/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/utilities/SheetsViewModelInitializers.kt
+++ b/ui/timeline/src/commonMain/kotlin/com/tunjid/heron/timeline/utilities/SheetsViewModelInitializers.kt
@@ -2,6 +2,7 @@ package com.tunjid.heron.timeline.utilities
 
 import com.tunjid.heron.timeline.ui.sheets.embedrecordoptions.EmbeddableRecordOptionsViewModelInitializer
 import com.tunjid.heron.timeline.ui.sheets.mutedwords.MutedWordsViewModelInitializer
+import com.tunjid.heron.timeline.ui.sheets.postinteractions.PostInteractionsViewModelInitializer
 import com.tunjid.heron.timeline.ui.sheets.postoptions.PostOptionsViewModelInitializer
 import com.tunjid.heron.timeline.ui.sheets.selectlist.SelectListViewModelInitializer
 import com.tunjid.heron.timeline.ui.sheets.threadgate.ThreadGateViewModelInitializer
@@ -12,4 +13,5 @@ class SheetsViewModelInitializers(
     val threadGateViewModelInitializer: ThreadGateViewModelInitializer,
     val embeddableRecordOptionsViewModelInitializer: EmbeddableRecordOptionsViewModelInitializer,
     val selectListViewModelInitializer: SelectListViewModelInitializer,
+    val postInteractionsViewModelInitializer: PostInteractionsViewModelInitializer,
 )


### PR DESCRIPTION
### What
- Migrates `PostInteractionsSheetState` to the ViewModel-backed pattern from #1335. `PostInteractionsViewModel` loads `isSignedIn` from `AuthRepository` directly.

### Why
- `isSignedIn` was previously passed as a parameter and updated reactively via `.also { it.isSignedIn = isSignedIn }`, coupling the sheet to the feature's state. The ViewModel now owns this concern.

### How

**ViewModel**
- `PostInteractionsViewModel` is `@AssistedInject`, 
- `@Snapshottable`=state, loads `isSignedIn` from `AuthRepository.signedInUser` via`launchAndCollect` in the producer block.

**SheetState**
- `showingAction` remains on the SheetState it is pure UI state tracking which interaction the user tapped, set via `onInteraction()`and cleared on `onHidden()`. 
- A public `state` getter exposes`PostInteractionsState` for external reads without triggering production.

**LaunchedEffect placement**
- The `LaunchedEffect(state.showingAction)` intentionally lives outside`ModalBottomSheet {}`. Like, bookmark, and gate interactions are confirmed immediately without showing the sheet at all. 
- It reads`state.state.isSignedIn` via the public getter snapshot state directly, no `produceState()` called outside the sheet.

**Callbacks stay as callbacks**
- `onInteractionConfirmed`, `onSignInClicked`, and `onQuotePostClicked`remain as parameters. Write operations go through each feature's`WriteQueue`; navigation to sign-in and compose post is feature- specific. 