### PR TITLE
Restructure app level state holders

### DIFF
--- a/androidApp/src/main/kotlin/com/tunjid/heron/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/tunjid/heron/MainActivity.kt
@@ -36,7 +36,8 @@ import com.google.firebase.messaging.FirebaseMessaging
 import com.tunjid.heron.data.core.types.GenericUri
 import com.tunjid.heron.ui.scaffold.notifications.NotificationAction
 import com.tunjid.heron.ui.scaffold.scaffold.App
-import com.tunjid.heron.ui.scaffold.scaffold.isShowingSplashScreen
+import com.tunjid.heron.ui.scaffold.scaffold.AppState.Companion.isShowingSplashScreen
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 
@@ -73,7 +74,7 @@ class MainActivity : ComponentActivity() {
             LaunchedEffect(isSystemInDarkTheme) {
                 snapshotFlow { appState.isShowingSplashScreen }
                     .first { !it }
-                delay(STATUS_BAR_ICON_DELAY_MS)
+                delay(STATUS_BAR_ICON_DELAY)
                 windowInsetsController.isAppearanceLightStatusBars = !isSystemInDarkTheme
             }
         }
@@ -126,4 +127,4 @@ fun AppAndroidPreview() {
     App()
 }
 
-private const val STATUS_BAR_ICON_DELAY_MS = 500L
+private val STATUS_BAR_ICON_DELAY = 500.milliseconds

--- a/ui/core/src/commonMain/kotlin/com/tunjid/heron/ui/stateproduction/ViewModelInitializer.kt
+++ b/ui/core/src/commonMain/kotlin/com/tunjid/heron/ui/stateproduction/ViewModelInitializer.kt
@@ -1,0 +1,15 @@
+package com.tunjid.heron.ui.stateproduction
+
+import androidx.compose.runtime.Stable
+import kotlin.reflect.KClass
+
+@Stable
+interface ViewModelInitializer {
+    fun sheetViewModelInitializer(
+        modelClass: KClass<out SheetViewModel>,
+    ): SheetViewModelInitializer
+
+    fun routeViewModelInitializer(
+        modelClass: KClass<out RouteViewModel>,
+    ): RouteViewModelInitializer
+}

--- a/ui/scaffold/src/commonMain/kotlin/com/tunjid/heron/ui/scaffold/identity/IdentityState.kt
+++ b/ui/scaffold/src/commonMain/kotlin/com/tunjid/heron/ui/scaffold/identity/IdentityState.kt
@@ -1,19 +1,13 @@
 package com.tunjid.heron.ui.scaffold.identity
 
 import androidx.compose.runtime.Stable
-import com.tunjid.heron.data.core.models.Post
-import com.tunjid.heron.data.core.models.PostUri
 import com.tunjid.heron.data.core.models.Preferences
 import com.tunjid.heron.data.core.models.Profile
 import com.tunjid.heron.data.core.models.SessionSummary
-import com.tunjid.heron.data.core.types.PostId
 import com.tunjid.heron.data.utilities.writequeue.FailedWrite
-import com.tunjid.heron.data.utilities.writequeue.Writable
 import com.tunjid.heron.ui.text.Memo
 import com.tunjid.snapshottable.SnapshotSpec
 import com.tunjid.snapshottable.Snapshottable
-import kotlin.time.Clock
-import kotlinx.serialization.Transient
 
 sealed class IdentityAction(
     val key: String,
@@ -67,3 +61,9 @@ internal val IdentityState.isSignedIn
 
 internal val IdentityState.isStable
     get() = switchStatus is IdentityState.SwitchStatus.Stable
+
+internal val IdentityState.prefersCompactBottomNav: Boolean
+    get() = preferences?.local?.useCompactNavigation ?: false
+
+internal val IdentityState.prefersAutoHidingBottomNav: Boolean
+    get() = preferences?.local?.autoHideBottomNavigation ?: true

--- a/ui/scaffold/src/commonMain/kotlin/com/tunjid/heron/ui/scaffold/identity/IdentityStateHolder.kt
+++ b/ui/scaffold/src/commonMain/kotlin/com/tunjid/heron/ui/scaffold/identity/IdentityStateHolder.kt
@@ -1,5 +1,6 @@
 package com.tunjid.heron.ui.scaffold.identity
 
+import androidx.compose.runtime.Stable
 import com.tunjid.heron.data.core.utilities.Outcome
 import com.tunjid.heron.data.di.AppMainScope
 import com.tunjid.heron.data.network.NetworkMonitor
@@ -29,6 +30,7 @@ import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
+@Stable
 interface IdentityStateHolder : ActionSuspendingStateMutator<IdentityAction, IdentityState>
 
 @Inject

--- a/ui/scaffold/src/commonMain/kotlin/com/tunjid/heron/ui/scaffold/navigation/NavigationStateHolder.kt
+++ b/ui/scaffold/src/commonMain/kotlin/com/tunjid/heron/ui/scaffold/navigation/NavigationStateHolder.kt
@@ -16,6 +16,7 @@
 
 package com.tunjid.heron.ui.scaffold.navigation
 
+import androidx.compose.runtime.Stable
 import com.tunjid.heron.data.core.types.ProfileId
 import com.tunjid.heron.data.di.AppMainScope
 import com.tunjid.heron.data.repository.AuthRepository
@@ -51,6 +52,7 @@ import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.scan
 import kotlinx.coroutines.launch
 
+@Stable
 interface NavigationStateHolder : ActionSuspendingStateMutator<NavigationMutation, NavigationState>
 typealias NavigationMutation = NavigationContext.() -> MultiStackNav
 

--- a/ui/scaffold/src/commonMain/kotlin/com/tunjid/heron/ui/scaffold/notifications/NotificationStateHolder.kt
+++ b/ui/scaffold/src/commonMain/kotlin/com/tunjid/heron/ui/scaffold/notifications/NotificationStateHolder.kt
@@ -16,6 +16,7 @@
 
 package com.tunjid.heron.ui.scaffold.notifications
 
+import androidx.compose.runtime.Stable
 import com.tunjid.heron.data.core.utilities.Outcome
 import com.tunjid.heron.data.di.AppMainScope
 import com.tunjid.heron.data.logging.LogPriority
@@ -39,6 +40,7 @@ import kotlinx.coroutines.flow.flatMapMerge
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.withTimeoutOrNull
 
+@Stable
 interface NotificationStateHolder : ActionSuspendingStateMutator<NotificationAction, NotificationState>
 
 @Inject

--- a/ui/scaffold/src/commonMain/kotlin/com/tunjid/heron/ui/scaffold/scaffold/App.kt
+++ b/ui/scaffold/src/commonMain/kotlin/com/tunjid/heron/ui/scaffold/scaffold/App.kt
@@ -34,10 +34,15 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.navigationevent.NavigationEvent
+import androidx.navigationevent.NavigationEventTransitionState
+import androidx.navigationevent.compose.LocalNavigationEventDispatcherOwner
 import com.tunjid.composables.splitlayout.SplitLayout
 import com.tunjid.heron.images.LocalImageLoader
 import com.tunjid.heron.media.video.LocalVideoPlayerController
 import com.tunjid.heron.ui.UiTokens
+import com.tunjid.heron.ui.scaffold.scaffold.AppState.Companion.displayStates
+import com.tunjid.heron.ui.scaffold.scaffold.AppState.Companion.rememberMultiPaneDisplayState
 import com.tunjid.heron.ui.scaffold.scaffold.PaneAnchorState.Companion.DraggableThumb
 import com.tunjid.heron.ui.scaffold.ui.theme.AppTheme
 import com.tunjid.heron.ui.scaffold.ui.theme.DarkThemeConfig
@@ -48,6 +53,8 @@ import com.tunjid.treenav.compose.threepane.ThreePane
 import com.tunjid.treenav.compose.threepane.panedecorators.threePaneAdaptiveDecorator
 import com.tunjid.treenav.compose.threepane.panedecorators.threePaneMovableSharedElementDecorator
 import com.tunjid.treenav.strings.Route
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
 
 /**
  * Root scaffold for the app
@@ -57,7 +64,10 @@ fun App(
     modifier: Modifier,
     appState: AppState,
 ) {
-    val localPrefs = appState.identityState.preferences?.local
+    val displayScaffoldStates = remember(appState) {
+        appState.displayStates()
+    }
+    val localPrefs = displayScaffoldStates.identityState.preferences?.local
     AppTheme(
         useDarkTheme = when (
             DarkThemeConfig.fromOrdinal(localPrefs?.darkThemeConfigOrdinal ?: 0)
@@ -113,15 +123,12 @@ fun App(
                         modifier = Modifier.fillMaxSize(),
                         state = displayState,
                     ) {
-                        val splitPaneState = remember {
-                            SplitPaneState(
+                        val displayScaffoldState = remember(displayScaffoldStates) {
+                            DisplayScaffoldState(
                                 paneNavigationState = { this.paneNavigationState },
                                 density = density,
                                 windowWidth = windowWidth,
-                                initialAnchor = appState.lastPaneAnchor,
-                                hasCompatBottomNav = {
-                                    appState.prefersCompactBottomNav
-                                },
+                                staticStates = displayScaffoldStates,
                             )
                         }.also {
                             it.update(
@@ -129,33 +136,57 @@ fun App(
                             )
                         }
                         CompositionLocalProvider(
-                            LocalSplitPaneState provides splitPaneState,
+                            LocalDisplayScaffoldState provides displayScaffoldState,
                         ) {
                             SplitLayout(
-                                state = splitPaneState.splitLayoutState,
+                                state = displayScaffoldState.splitLayoutState,
                                 modifier = modifier
                                     .fillMaxSize(),
                                 itemSeparators = { _, offset ->
                                     DraggableThumb(
-                                        splitLayoutState = splitPaneState.splitLayoutState,
-                                        paneAnchorState = splitPaneState.paneAnchorState,
+                                        splitLayoutState = displayScaffoldState.splitLayoutState,
+                                        paneAnchorState = displayScaffoldState.paneAnchorState,
                                         offset = offset,
                                     )
                                 },
                                 itemContent = { index ->
-                                    Destination(splitPaneState.filteredPaneOrder[index])
+                                    Destination(displayScaffoldState.filteredPaneOrder[index])
                                 },
                             )
                         }
                         LaunchedEffect(Unit) {
                             snapshotFlow {
-                                splitPaneState.paneAnchorState.currentPaneAnchor
+                                displayScaffoldState.paneAnchorState.currentPaneAnchor
                             }.collect { anchor ->
-                                appState.onPaneAnchorChanged(
+                                displayScaffoldState.onPaneAnchorChanged(
                                     anchor = anchor,
                                     destinationId = paneNavigationState.destinationId,
                                 )
                             }
+                        }
+
+                        val navigationEventDispatcher = LocalNavigationEventDispatcherOwner.current!!
+                            .navigationEventDispatcher
+
+                        LaunchedEffect(navigationEventDispatcher) {
+                            combine(
+                                navigationEventDispatcher.transitionState,
+                                navigationEventDispatcher.history,
+                            ) { transitionState, navigationEventHistory ->
+                                val navigationEventInfo = navigationEventHistory.mergedHistory
+                                    .getOrNull(navigationEventHistory.currentIndex)
+                                when (transitionState) {
+                                    NavigationEventTransitionState.Idle -> DisplayScaffoldState.DismissBehavior.None
+                                    is NavigationEventTransitionState.InProgress -> when {
+                                        navigationEventInfo is SecondaryPaneCloseNavigationEventInfo -> DisplayScaffoldState.DismissBehavior.Gesture.SlideToPop
+                                        transitionState.latestEvent.swipeEdge == NavigationEvent.EDGE_NONE -> DisplayScaffoldState.DismissBehavior.Gesture.DragToPop
+                                        else -> DisplayScaffoldState.DismissBehavior.Gesture.ScaleToPop
+                                    }
+                                }
+                            }
+                                .collectLatest {
+                                    displayScaffoldState.dismissBehavior = it
+                                }
                         }
                     }
                 }

--- a/ui/scaffold/src/commonMain/kotlin/com/tunjid/heron/ui/scaffold/scaffold/App.kt
+++ b/ui/scaffold/src/commonMain/kotlin/com/tunjid/heron/ui/scaffold/scaffold/App.kt
@@ -123,9 +123,13 @@ fun App(
                         modifier = Modifier.fillMaxSize(),
                         state = displayState,
                     ) {
-                        val displayScaffoldState = remember(displayScaffoldStates) {
+                        val displayScope = this
+                        val displayScaffoldState = remember(
+                            displayScaffoldStates,
+                            displayScope,
+                        ) {
                             DisplayScaffoldState(
-                                paneNavigationState = { this.paneNavigationState },
+                                paneNavigationState = { displayScope.paneNavigationState },
                                 density = density,
                                 windowWidth = windowWidth,
                                 staticStates = displayScaffoldStates,
@@ -154,7 +158,10 @@ fun App(
                                 },
                             )
                         }
-                        LaunchedEffect(Unit) {
+                        LaunchedEffect(
+                            displayScaffoldState,
+                            displayScope,
+                        ) {
                             snapshotFlow {
                                 displayScaffoldState.paneAnchorState.currentPaneAnchor
                             }.collect { anchor ->
@@ -168,7 +175,10 @@ fun App(
                         val navigationEventDispatcher = LocalNavigationEventDispatcherOwner.current!!
                             .navigationEventDispatcher
 
-                        LaunchedEffect(navigationEventDispatcher) {
+                        LaunchedEffect(
+                            navigationEventDispatcher,
+                            displayScaffoldState,
+                        ) {
                             combine(
                                 navigationEventDispatcher.transitionState,
                                 navigationEventDispatcher.history,

--- a/ui/scaffold/src/commonMain/kotlin/com/tunjid/heron/ui/scaffold/scaffold/AppPanes.kt
+++ b/ui/scaffold/src/commonMain/kotlin/com/tunjid/heron/ui/scaffold/scaffold/AppPanes.kt
@@ -283,7 +283,7 @@ internal class PaneAnchorState(
  */
 @Composable
 fun PaneScaffoldState.SecondaryPaneCloseBackHandler() {
-    val currentlyEnabled = remember {
+    val currentlyEnabled = remember(this) {
         derivedStateOf {
             paneState.pane == ThreePane.Primary &&
                 displayScaffoldState.filteredPaneOrder.size > 1 &&

--- a/ui/scaffold/src/commonMain/kotlin/com/tunjid/heron/ui/scaffold/scaffold/AppPanes.kt
+++ b/ui/scaffold/src/commonMain/kotlin/com/tunjid/heron/ui/scaffold/scaffold/AppPanes.kt
@@ -286,14 +286,14 @@ fun PaneScaffoldState.SecondaryPaneCloseBackHandler() {
     val currentlyEnabled = remember {
         derivedStateOf {
             paneState.pane == ThreePane.Primary &&
-                splitPaneState.filteredPaneOrder.size > 1 &&
-                appState.dismissBehavior != AppState.DismissBehavior.Gesture.DragToPop &&
+                displayScaffoldState.filteredPaneOrder.size > 1 &&
+                displayScaffoldState.dismissBehavior != DisplayScaffoldState.DismissBehavior.Gesture.DragToPop &&
                 // Only enable if going back to a single pane layout
-                appState.navigationState.multiStackNav.pop().current?.children?.isEmpty() ?: false
+                displayScaffoldState.staticStates.navigationState.multiStackNav.pop().current?.children?.isEmpty() ?: false
         }
     }
 
-    val paneAnchorState = splitPaneState.paneAnchorState
+    val paneAnchorState = displayScaffoldState.paneAnchorState
     var started by remember { mutableStateOf(false) }
     var widthAtStart by remember { mutableIntStateOf(0) }
     var desiredPaneWidth by remember { mutableFloatStateOf(0f) }
@@ -308,7 +308,7 @@ fun PaneScaffoldState.SecondaryPaneCloseBackHandler() {
         },
         onBackCompleted = {
             started = false
-            appState.pop()
+            displayScaffoldState.pop()
         },
     )
 
@@ -323,7 +323,7 @@ fun PaneScaffoldState.SecondaryPaneCloseBackHandler() {
                 when (state) {
                     NavigationEventTransitionState.Idle -> wasIdle = true
                     is NavigationEventTransitionState.InProgress -> if (currentlyEnabled.value) {
-                        check(appState.dismissBehavior != AppState.DismissBehavior.Gesture.DragToPop) {
+                        check(displayScaffoldState.dismissBehavior != DisplayScaffoldState.DismissBehavior.Gesture.DragToPop) {
                             "The secondary pane close back handler should not run when dragging to dismiss"
                         }
                         if (wasIdle) {
@@ -368,10 +368,10 @@ fun PaneScaffoldState.SecondaryPaneCloseBackHandler() {
 
     // Pop when fully expanded
     LaunchedEffect(Unit) {
-        snapshotFlow { splitPaneState.paneAnchorState.currentPaneAnchor }
+        snapshotFlow { displayScaffoldState.paneAnchorState.currentPaneAnchor }
             .collect { anchor ->
                 if (currentlyEnabled.value && anchor == PaneAnchor.Full) {
-                    appState.pop()
+                    displayScaffoldState.pop()
                 }
             }
     }

--- a/ui/scaffold/src/commonMain/kotlin/com/tunjid/heron/ui/scaffold/scaffold/AppState.kt
+++ b/ui/scaffold/src/commonMain/kotlin/com/tunjid/heron/ui/scaffold/scaffold/AppState.kt
@@ -16,64 +16,44 @@
 
 package com.tunjid.heron.ui.scaffold.scaffold
 
-import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
-import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.movableContentOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.staticCompositionLocalOf
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.Dp
 import androidx.lifecycle.compose.LifecycleResumeEffect
 import androidx.lifecycle.compose.LifecycleStartEffect
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.NavEntryDecorator
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
-import androidx.navigationevent.NavigationEvent
-import androidx.navigationevent.NavigationEventTransitionState
-import androidx.navigationevent.compose.LocalNavigationEventDispatcherOwner
-import com.tunjid.composables.splitlayout.SplitLayoutState
 import com.tunjid.heron.data.core.types.GenericUri
 import com.tunjid.heron.data.core.types.RecordUri
 import com.tunjid.heron.images.ImageLoader
 import com.tunjid.heron.media.video.VideoPlayerController
-import com.tunjid.heron.ui.UiTokens
-import com.tunjid.heron.ui.scaffold.identity.IdentityAction
 import com.tunjid.heron.ui.scaffold.identity.IdentityStateHolder
-import com.tunjid.heron.ui.scaffold.identity.isSignedIn
-import com.tunjid.heron.ui.scaffold.navigation.AppStack
-import com.tunjid.heron.ui.scaffold.navigation.NavItem
 import com.tunjid.heron.ui.scaffold.navigation.NavigationStateHolder
 import com.tunjid.heron.ui.scaffold.navigation.deepLinkTo
 import com.tunjid.heron.ui.scaffold.navigation.isShowingSplashScreen
-import com.tunjid.heron.ui.scaffold.navigation.navItemSelected
-import com.tunjid.heron.ui.scaffold.navigation.signInDestination
-import com.tunjid.heron.ui.scaffold.navigation.tasksDestination
 import com.tunjid.heron.ui.scaffold.notifications.NotificationAction
 import com.tunjid.heron.ui.scaffold.notifications.NotificationStateHolder
-import com.tunjid.heron.ui.scaffold.scaffold.PaneAnchorState.Companion.MinPaneWidth
+import com.tunjid.heron.ui.stateproduction.RouteViewModel
 import com.tunjid.heron.ui.stateproduction.RouteViewModelInitializer
+import com.tunjid.heron.ui.stateproduction.SheetViewModel
 import com.tunjid.heron.ui.stateproduction.SheetViewModelInitializer
+import com.tunjid.heron.ui.stateproduction.ViewModelInitializer
 import com.tunjid.heron.ui.stateproduction.withSnapshotNotifications
 import com.tunjid.mutator.compose.produceState
 import com.tunjid.treenav.MultiStackNav
-import com.tunjid.treenav.StackNav
 import com.tunjid.treenav.compose.MultiPaneDisplayState
 import com.tunjid.treenav.compose.PaneEntry
-import com.tunjid.treenav.compose.PaneNavigationState
 import com.tunjid.treenav.compose.multiPaneDisplayBackstack
 import com.tunjid.treenav.compose.panedecorators.PaneDecorator
 import com.tunjid.treenav.compose.threepane.ThreePane
 import com.tunjid.treenav.compose.threepane.threePaneEntry
-import com.tunjid.treenav.current
 import com.tunjid.treenav.pop
 import com.tunjid.treenav.requireCurrent
 import com.tunjid.treenav.strings.PathPattern
@@ -81,8 +61,6 @@ import com.tunjid.treenav.strings.Route
 import com.tunjid.treenav.strings.toRouteTrie
 import kotlin.reflect.KClass
 import kotlin.time.Duration.Companion.seconds
-import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 
 @Stable
@@ -96,169 +74,47 @@ class AppState(
     internal val sheetViewModelInitializers: Map<KClass<*>, SheetViewModelInitializer>,
     internal val routeViewModelInitializers: Map<KClass<*>, RouteViewModelInitializer>,
 ) {
-    internal val identityState
-        get() = identityStateHolder.state
-
-    internal val navigationState
-        get() = navigationStateHolder.state
-
-    private val notificationState
-        get() = notificationStateHolder.state
-
-    internal var showNavigation by mutableStateOf(false)
-
     var showPlatformSplashScreen by mutableStateOf(true)
-        internal set
+        private set
 
-    internal val navItems by derivedStateOf {
-        currentNavItems()
+    internal val viewModelInitializer = object : ViewModelInitializer {
+        override fun sheetViewModelInitializer(
+            modelClass: KClass<out SheetViewModel>,
+        ): SheetViewModelInitializer =
+            sheetViewModelInitializers[modelClass]
+                ?: throw IllegalStateException(
+                    "No SheetViewModelInitializer registered for ${modelClass.simpleName}. Ensure it is contributed in SheetBindings.",
+                )
+
+        override fun routeViewModelInitializer(
+            modelClass: KClass<out RouteViewModel>,
+        ): RouteViewModelInitializer =
+            routeViewModelInitializers[modelClass]
+                ?: throw IllegalStateException(
+                    "No RouteViewModelInitializer registered for ${modelClass.simpleName}. Ensure it is contributed in the feature's Bindings.",
+                )
     }
-
-    internal var dismissBehavior by mutableStateOf<DismissBehavior>(DismissBehavior.None)
-        private set
-
-    internal var lastPaneAnchor by mutableStateOf(PaneAnchor.Half)
-        private set
-
-    internal val movableNavigationBar =
-        movableContentOf<Modifier, () -> Boolean> { modifier, onNavItemReselected ->
-            PaneNavigationBar(
-                modifier = modifier,
-                onNavItemReselected = onNavItemReselected,
-            )
-        }
-
-    internal val movableNavigationRail =
-        movableContentOf<Modifier, () -> Boolean> { modifier, onNavItemReselected ->
-            PaneNavigationRail(
-                modifier = modifier,
-                onNavItemReselected = onNavItemReselected,
-            )
-        }
 
     private val entryTrie = entryMap
         .mapKeys { (template) -> PathPattern(template) }
         .toRouteTrie()
 
-    @Composable
-    internal fun rememberMultiPaneDisplayState(
-        paneDecorators: List<PaneDecorator<MultiStackNav, Route, ThreePane>>,
-    ): MultiPaneDisplayState<MultiStackNav, Route, ThreePane> {
-        val saveableStateHolderNavEntryDecorator =
-            rememberSaveableStateHolderNavEntryDecorator<Route>()
-        val viewModelStoreNavEntryDecorator =
-            rememberViewModelStoreNavEntryDecorator<Route>()
-
-        val displayState = remember {
-            MultiPaneDisplayState(
-                panes = ThreePane.entries.toList(),
-                paneDecorators = paneDecorators,
-                navigationState = derivedStateOf(navigationState::multiStackNav),
-                backStackTransform = MultiStackNav::multiPaneDisplayBackstack,
-                destinationTransform = MultiStackNav::requireCurrent,
-                popTransform = MultiStackNav::pop,
-                onPopped = { poppedNavigationState ->
-                    navigationStateHolder.accept {
-                        poppedNavigationState
-                    }
-                },
-                navEntryDecorators = listOf(
-                    saveableStateHolderNavEntryDecorator,
-                    viewModelStoreNavEntryDecorator,
-                    splashVisibilityNavEntryDecorator(),
-                ),
-                entryProvider = { node ->
-                    entryTrie[node] ?: threePaneEntry(
-                        render = { },
-                    )
-                },
-            )
-        }
-
-        identityStateHolder.produceState()
-        navigationStateHolder.produceState()
-        notificationStateHolder.produceState()
-
-        // TODO: Figure out a way to do this in the background with KMP
-        LifecycleResumeEffect(Unit) {
-            notificationStateHolder.accept(
-                NotificationAction.ToggleUnreadNotificationsMonitor(monitor = true),
-            )
-            onPauseOrDispose {
-                notificationStateHolder.accept(
-                    NotificationAction.ToggleUnreadNotificationsMonitor(monitor = false),
-                )
-            }
-        }
-
-        LifecycleStartEffect(videoPlayerController) {
-            onStopOrDispose { videoPlayerController.pauseActiveVideo() }
-        }
-
-        val navigationEventDispatcher = LocalNavigationEventDispatcherOwner.current!!
-            .navigationEventDispatcher
-
-        LaunchedEffect(navigationEventDispatcher) {
-            combine(
-                navigationEventDispatcher.transitionState,
-                navigationEventDispatcher.history,
-            ) { transitionState, navigationEventHistory ->
-                val navigationEventInfo = navigationEventHistory.mergedHistory
-                    .getOrNull(navigationEventHistory.currentIndex)
-                when (transitionState) {
-                    NavigationEventTransitionState.Idle -> DismissBehavior.None
-                    is NavigationEventTransitionState.InProgress -> when {
-                        navigationEventInfo is SecondaryPaneCloseNavigationEventInfo -> DismissBehavior.Gesture.SlideToPop
-                        transitionState.latestEvent.swipeEdge == NavigationEvent.EDGE_NONE -> DismissBehavior.Gesture.DragToPop
-                        else -> DismissBehavior.Gesture.ScaleToPop
-                    }
+    private val splashVisibilityNavEntryDecorator: NavEntryDecorator<Route> =
+        NavEntryDecorator { entry ->
+            entry.Content()
+            if (showPlatformSplashScreen) {
+                LifecycleStartEffect(Unit) {
+                    showPlatformSplashScreen = false
+                    onStopOrDispose { }
                 }
             }
-                .collectLatest(::dismissBehavior::set)
         }
-
-        return displayState
-    }
-
-    internal fun onNavItemSelected(navItem: NavItem) {
-        navigationStateHolder.accept { navState.navItemSelected(item = navItem) }
-    }
-
-    internal fun pop() =
-        navigationStateHolder.accept {
-            navState.pop()
-        }
-
-    internal fun onNavigateToTasks() =
-        navigationStateHolder.accept(
-            tasksDestination(showFailedWrites = true).navigationMutation,
-        )
-
-    internal fun addAccount() {
-        identityStateHolder.accept(
-            IdentityAction.Switch.Cancel,
-        )
-        navigationStateHolder.accept(
-            signInDestination().navigationMutation,
-        )
-    }
-
-    internal fun onPaneAnchorChanged(
-        anchor: PaneAnchor,
-        destinationId: String,
-    ) {
-        if (destinationId != navigationState.multiStackNav.current?.id || anchor == PaneAnchor.Full) return
-        lastPaneAnchor = anchor
-    }
 
     fun onDeepLink(uri: GenericUri) =
         navigationStateHolder.accept(deepLinkTo(uri))
 
     fun onNotificationAction(action: NotificationAction) =
         notificationStateHolder.accept(action)
-
-    fun onIdentityAction(action: IdentityAction) =
-        identityStateHolder.accept(action)
 
     /**
      * This method is called from outside compose and
@@ -268,127 +124,85 @@ class AppState(
         recordUri: RecordUri,
     ) = withSnapshotNotifications {
         snapshotFlow {
-            notificationState.processedNotificationRecordUris
+            notificationStateHolder.state.processedNotificationRecordUris
         }.first {
             recordUri in it
         }
     }
 
-    private fun currentNavItems(): List<NavItem> {
-        return navigationState.multiStackNav
-            .stacks
-            .map(StackNav::name)
-            .mapIndexedNotNull { index, name ->
-                val stack = AppStack.entries.firstOrNull { stack ->
-                    when (stack) {
-                        AppStack.Home -> stack.stackName == name
-                        AppStack.Search -> stack.stackName == name
-                        AppStack.Messages -> identityState.isSignedIn && stack.stackName == name
-                        AppStack.Notifications -> identityState.isSignedIn && stack.stackName == name
-                        AppStack.Auth -> stack.stackName == name
-                        AppStack.Splash -> stack.stackName == name
-                    }
-                } ?: return@mapIndexedNotNull null
-
-                NavItem(
-                    stack = stack,
-                    index = index,
-                    selected = navigationState.multiStackNav.currentIndex == index,
-                    badgeCount = if (stack == AppStack.Notifications) notificationState.unreadCount else 0L,
-                )
-            }
-    }
-
-    sealed class DismissBehavior {
-        data object None : DismissBehavior()
-        sealed class Gesture : DismissBehavior() {
-            data object DragToPop : Gesture()
-            data object SlideToPop : Gesture()
-            data object ScaleToPop : Gesture()
-        }
-    }
-
     companion object {
         val NOTIFICATION_PROCESSING_TIMEOUT_SECONDS = 10.seconds
-    }
-}
 
-val AppState.isShowingSplashScreen: Boolean
-    get() = navigationState.multiStackNav.isShowingSplashScreen
+        val AppState.isShowingSplashScreen: Boolean
+            get() = navigationStateHolder.state.multiStackNav.isShowingSplashScreen
 
-private fun AppState.splashVisibilityNavEntryDecorator(): NavEntryDecorator<Route> = NavEntryDecorator { entry ->
-    entry.Content()
-    if (showPlatformSplashScreen) {
-        LifecycleStartEffect(Unit) {
-            showPlatformSplashScreen = false
-            onStopOrDispose { }
+        @Composable
+        internal fun AppState.rememberMultiPaneDisplayState(
+            paneDecorators: List<PaneDecorator<MultiStackNav, Route, ThreePane>>,
+        ): MultiPaneDisplayState<MultiStackNav, Route, ThreePane> {
+            val saveableStateHolderNavEntryDecorator =
+                rememberSaveableStateHolderNavEntryDecorator<Route>()
+            val viewModelStoreNavEntryDecorator =
+                rememberViewModelStoreNavEntryDecorator<Route>()
+
+            val displayState = remember {
+                MultiPaneDisplayState(
+                    panes = ThreePane.entries.toList(),
+                    paneDecorators = paneDecorators,
+                    navigationState = derivedStateOf(navigationStateHolder.state::multiStackNav),
+                    backStackTransform = MultiStackNav::multiPaneDisplayBackstack,
+                    destinationTransform = MultiStackNav::requireCurrent,
+                    popTransform = MultiStackNav::pop,
+                    onPopped = { poppedNavigationState ->
+                        navigationStateHolder.accept {
+                            poppedNavigationState
+                        }
+                    },
+                    navEntryDecorators = listOf(
+                        saveableStateHolderNavEntryDecorator,
+                        viewModelStoreNavEntryDecorator,
+                        splashVisibilityNavEntryDecorator,
+                    ),
+                    entryProvider = { node ->
+                        entryTrie[node] ?: threePaneEntry(
+                            render = { },
+                        )
+                    },
+                )
+            }
+
+            identityStateHolder.produceState()
+            navigationStateHolder.produceState()
+            notificationStateHolder.produceState()
+
+            // TODO: Figure out a way to do this in the background with KMP
+            LifecycleResumeEffect(Unit) {
+                notificationStateHolder.accept(
+                    NotificationAction.ToggleUnreadNotificationsMonitor(monitor = true),
+                )
+                onPauseOrDispose {
+                    notificationStateHolder.accept(
+                        NotificationAction.ToggleUnreadNotificationsMonitor(monitor = false),
+                    )
+                }
+            }
+
+            LifecycleStartEffect(videoPlayerController) {
+                onStopOrDispose { videoPlayerController.pauseActiveVideo() }
+            }
+
+            return displayState
         }
-    }
-}
 
-@Stable
-internal class SplitPaneState(
-    paneNavigationState: () -> PaneNavigationState<ThreePane, Route>,
-    density: Density,
-    initialAnchor: PaneAnchor,
-    private val windowWidth: State<Dp>,
-    private val hasCompatBottomNav: () -> Boolean,
-) {
-    internal var density by mutableStateOf(density)
-
-    internal val paneAnchorState = PaneAnchorState(
-        initialMaxWidth = with(density) { windowWidth.value.roundToPx() },
-        initialAnchor = initialAnchor,
-    )
-
-    internal val filteredPaneOrder by derivedStateOf {
-        PaneRenderOrder.filter { paneNavigationState().destinationIn(it) != null }
-    }
-
-    internal val minPaneWidth: Dp
-        get() = (windowWidth.value * 0.5f) - UiTokens.bottomNavHeight(
-            isCompact = hasCompatBottomNav(),
-        )
-
-    internal val splitLayoutState = SplitLayoutState(
-        orientation = Orientation.Horizontal,
-        maxCount = PaneRenderOrder.size,
-        minSize = MinPaneWidth,
-        visibleCount = {
-            filteredPaneOrder.size
-        },
-        keyAtIndex = { index ->
-            filteredPaneOrder[index]
-        },
-    )
-
-    internal val isMediumScreenWidthOrWider
-        get() = windowWidth.value >= UiTokens.SecondaryPaneMinWidthBreakpoint
-
-    fun update(
-        density: Density,
-    ) {
-        this.density = density
-        paneAnchorState.updateMaxWidth(
-            density = density,
-            maxWidth = with(density) { windowWidth.value.roundToPx() },
+        fun AppState.displayStates() = DisplayScaffoldState.StaticStates(
+            identityStateHolder = identityStateHolder,
+            navigationStateHolder = navigationStateHolder,
+            notificationStateHolder = notificationStateHolder,
         )
     }
 }
 
-internal val AppState.prefersCompactBottomNav: Boolean
-    get() = identityState.preferences?.local?.useCompactNavigation ?: false
-
-internal val AppState.prefersAutoHidingBottomNav: Boolean
-    get() = identityState.preferences?.local?.autoHideBottomNavigation ?: true
-
-private val PaneRenderOrder = listOf(
-    ThreePane.Tertiary,
-    ThreePane.Secondary,
-    ThreePane.Primary,
-)
-
-internal val LocalSplitPaneState = staticCompositionLocalOf<SplitPaneState> {
+internal val LocalDisplayScaffoldState = staticCompositionLocalOf<DisplayScaffoldState> {
     throw IllegalStateException("No SplitPaneState provided")
 }
 

--- a/ui/scaffold/src/commonMain/kotlin/com/tunjid/heron/ui/scaffold/scaffold/AppState.kt
+++ b/ui/scaffold/src/commonMain/kotlin/com/tunjid/heron/ui/scaffold/scaffold/AppState.kt
@@ -203,7 +203,7 @@ class AppState(
 }
 
 internal val LocalDisplayScaffoldState = staticCompositionLocalOf<DisplayScaffoldState> {
-    throw IllegalStateException("No SplitPaneState provided")
+    throw IllegalStateException("No DisplayScaffoldState provided")
 }
 
 internal val LocalAppState = staticCompositionLocalOf<AppState> {

--- a/ui/scaffold/src/commonMain/kotlin/com/tunjid/heron/ui/scaffold/scaffold/DisplayScaffoldState.kt
+++ b/ui/scaffold/src/commonMain/kotlin/com/tunjid/heron/ui/scaffold/scaffold/DisplayScaffoldState.kt
@@ -1,0 +1,214 @@
+package com.tunjid.heron.ui.scaffold.scaffold
+
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.movableContentWithReceiverOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import com.tunjid.composables.splitlayout.SplitLayoutState
+import com.tunjid.heron.ui.UiTokens
+import com.tunjid.heron.ui.scaffold.identity.IdentityAction
+import com.tunjid.heron.ui.scaffold.identity.IdentityStateHolder
+import com.tunjid.heron.ui.scaffold.identity.isSignedIn
+import com.tunjid.heron.ui.scaffold.identity.prefersCompactBottomNav
+import com.tunjid.heron.ui.scaffold.navigation.AppStack
+import com.tunjid.heron.ui.scaffold.navigation.NavItem
+import com.tunjid.heron.ui.scaffold.navigation.NavigationMutation
+import com.tunjid.heron.ui.scaffold.navigation.NavigationStateHolder
+import com.tunjid.heron.ui.scaffold.navigation.navItemSelected
+import com.tunjid.heron.ui.scaffold.navigation.signInDestination
+import com.tunjid.heron.ui.scaffold.navigation.tasksDestination
+import com.tunjid.heron.ui.scaffold.notifications.NotificationStateHolder
+import com.tunjid.mutator.invoke
+import com.tunjid.treenav.StackNav
+import com.tunjid.treenav.compose.PaneNavigationState
+import com.tunjid.treenav.compose.threepane.ThreePane
+import com.tunjid.treenav.current
+import com.tunjid.treenav.pop
+import com.tunjid.treenav.strings.Route
+
+/**
+ * The scaffold state for the app for
+ * a given [com.tunjid.treenav.compose.MultiPaneDisplayScope].
+ */
+@Stable
+class DisplayScaffoldState internal constructor(
+    paneNavigationState: () -> PaneNavigationState<ThreePane, Route>,
+    density: Density,
+    internal val staticStates: StaticStates,
+    private val windowWidth: State<Dp>,
+) {
+    internal var density by mutableStateOf(density)
+
+    internal var showNavigation by mutableStateOf(false)
+    internal var dismissBehavior by mutableStateOf<DismissBehavior>(DismissBehavior.None)
+
+    internal var currentPaneAnchor by mutableStateOf(PaneAnchor.Half)
+        private set
+
+    internal val paneAnchorState = PaneAnchorState(
+        initialMaxWidth = with(density) { windowWidth.value.roundToPx() },
+        initialAnchor = currentPaneAnchor,
+    )
+
+    internal val filteredPaneOrder by derivedStateOf {
+        PaneRenderOrder.filter { paneNavigationState().destinationIn(it) != null }
+    }
+
+    internal val minPaneWidth: Dp
+        get() = (windowWidth.value * 0.5f) - UiTokens.bottomNavHeight(
+            isCompact = staticStates.identityState.prefersCompactBottomNav,
+        )
+
+    internal val splitLayoutState = SplitLayoutState(
+        orientation = Orientation.Horizontal,
+        maxCount = PaneRenderOrder.size,
+        minSize = PaneAnchorState.MinPaneWidth,
+        visibleCount = {
+            filteredPaneOrder.size
+        },
+        keyAtIndex = { index ->
+            filteredPaneOrder[index]
+        },
+    )
+
+    internal val isMediumScreenWidthOrWider
+        get() = windowWidth.value >= UiTokens.SecondaryPaneMinWidthBreakpoint
+
+    internal fun update(
+        density: Density,
+    ) {
+        this.density = density
+        paneAnchorState.updateMaxWidth(
+            density = density,
+            maxWidth = with(density) { windowWidth.value.roundToPx() },
+        )
+    }
+
+    internal fun onNavigateToTasks() =
+        staticStates.onNavigationAction(
+            tasksDestination(showFailedWrites = true).navigationMutation,
+        )
+
+    internal fun addAccount() {
+        staticStates.onIdentityAction(
+            IdentityAction.Switch.Cancel,
+        )
+        staticStates.onNavigationAction(
+            signInDestination().navigationMutation,
+        )
+    }
+
+    internal fun onPaneAnchorChanged(
+        anchor: PaneAnchor,
+        destinationId: String,
+    ) {
+        if (destinationId != staticStates.navigationState.multiStackNav.current?.id || anchor == PaneAnchor.Full) return
+        currentPaneAnchor = anchor
+    }
+
+    internal fun pop() =
+        staticStates.onNavigationAction {
+            navState.pop()
+        }
+
+    sealed class DismissBehavior {
+        data object None : DismissBehavior()
+        sealed class Gesture : DismissBehavior() {
+            data object DragToPop : Gesture()
+            data object SlideToPop : Gesture()
+            data object ScaleToPop : Gesture()
+        }
+    }
+
+    /**
+     * Elements on [DisplayScaffoldState] that are effectively singletons from
+     * the App's UI scaffold POV, though necessarily from the [AppState]'s.
+     * i.e, all [DisplayScaffoldState] instances share identical [DisplayScaffoldState.StaticStates]
+     * instances.
+     */
+    @Stable
+    class StaticStates(
+        private val identityStateHolder: IdentityStateHolder,
+        private val navigationStateHolder: NavigationStateHolder,
+        private val notificationStateHolder: NotificationStateHolder,
+    ) {
+        internal val identityState
+            get() = identityStateHolder.state
+
+        internal val navigationState
+            get() = navigationStateHolder.state
+
+        internal val notificationState
+            get() = notificationStateHolder.state
+
+        internal val movableNavigationBar =
+            movableContentWithReceiverOf<DisplayScaffoldState, Modifier, () -> Boolean> { modifier, onNavItemReselected ->
+                PaneNavigationBar(
+                    modifier = modifier,
+                    onNavItemReselected = onNavItemReselected,
+                )
+            }
+
+        internal val movableNavigationRail =
+            movableContentWithReceiverOf<DisplayScaffoldState, Modifier, () -> Boolean> { modifier, onNavItemReselected ->
+                PaneNavigationRail(
+                    modifier = modifier,
+                    onNavItemReselected = onNavItemReselected,
+                )
+            }
+
+        internal val navItems by derivedStateOf {
+            currentNavItems()
+        }
+
+        internal fun onNavItemSelected(navItem: NavItem) {
+            onNavigationAction { navState.navItemSelected(item = navItem) }
+        }
+
+        fun onIdentityAction(
+            action: IdentityAction,
+        ) = identityStateHolder(action)
+
+        fun onNavigationAction(
+            action: NavigationMutation,
+        ) = navigationStateHolder(action)
+
+        private fun currentNavItems(): List<NavItem> {
+            return navigationState.multiStackNav
+                .stacks
+                .map(StackNav::name)
+                .mapIndexedNotNull { index, name ->
+                    val stack = AppStack.entries.firstOrNull { stack ->
+                        when (stack) {
+                            AppStack.Home -> stack.stackName == name
+                            AppStack.Search -> stack.stackName == name
+                            AppStack.Messages -> identityState.isSignedIn && stack.stackName == name
+                            AppStack.Notifications -> identityState.isSignedIn && stack.stackName == name
+                            AppStack.Auth -> stack.stackName == name
+                            AppStack.Splash -> stack.stackName == name
+                        }
+                    } ?: return@mapIndexedNotNull null
+
+                    NavItem(
+                        stack = stack,
+                        index = index,
+                        selected = navigationState.multiStackNav.currentIndex == index,
+                        badgeCount = if (stack == AppStack.Notifications) notificationState.unreadCount else 0L,
+                    )
+                }
+        }
+    }
+}
+
+private val PaneRenderOrder = listOf(
+    ThreePane.Tertiary,
+    ThreePane.Secondary,
+    ThreePane.Primary,
+)

--- a/ui/scaffold/src/commonMain/kotlin/com/tunjid/heron/ui/scaffold/scaffold/PaneFab.kt
+++ b/ui/scaffold/src/commonMain/kotlin/com/tunjid/heron/ui/scaffold/scaffold/PaneFab.kt
@@ -100,7 +100,7 @@ fun PaneScaffoldState.PaneFab(
     var fabWidth by remember {
         mutableStateOf(DefaultFabSize)
     }
-    val clickable = enabled && appState.identityState.isStable
+    val clickable = enabled && displayScaffoldState.staticStates.identityState.isStable
     AnimatedVisibility(
         modifier = Modifier
             // Use the enter and exit transition on navigation
@@ -110,7 +110,7 @@ fun PaneScaffoldState.PaneFab(
                 animateEnterExit(enterTransition, exitTransition)
             }
             .onSizeChanged {
-                if (!splitPaneState.paneAnchorState.hasInteractions) {
+                if (!displayScaffoldState.paneAnchorState.hasInteractions) {
                     fabWidth = with(density) { it.width.toDp() }
                 }
             }
@@ -205,9 +205,9 @@ private fun FabIcon(icon: ImageVector) {
 fun PaneScaffoldState.isFabExpanded(
     offset: () -> Offset,
 ): Boolean {
-    val derivedState = remember(splitPaneState.density) {
+    val derivedState = remember(displayScaffoldState.density) {
         derivedStateOf {
-            offset().y < with(splitPaneState.density) { DefaultFabSize.toPx() }
+            offset().y < with(displayScaffoldState.density) { DefaultFabSize.toPx() }
         }
     }
     return derivedState.value
@@ -219,7 +219,7 @@ fun PaneScaffoldState.fabOffset(offset: Offset): IntOffset {
         x = offset.x.roundToInt(),
         y = min(
             offset.y.roundToInt(),
-            with(splitPaneState.density) {
+            with(displayScaffoldState.density) {
                 UiTokens.bottomNavHeight(
                     isCompact = prefersCompactBottomNav,
                 ).roundToPx()

--- a/ui/scaffold/src/commonMain/kotlin/com/tunjid/heron/ui/scaffold/scaffold/PaneNavigation.kt
+++ b/ui/scaffold/src/commonMain/kotlin/com/tunjid/heron/ui/scaffold/scaffold/PaneNavigation.kt
@@ -64,6 +64,7 @@ import androidx.compose.ui.unit.times
 import com.tunjid.composables.constrainedsize.constrainedSizePlacement
 import com.tunjid.heron.ui.UiTokens
 import com.tunjid.heron.ui.scaffold.identity.isStable
+import com.tunjid.heron.ui.scaffold.identity.prefersCompactBottomNav
 import com.tunjid.treenav.compose.Adaptation
 import com.tunjid.treenav.compose.NavigationEventStatus
 import com.tunjid.treenav.compose.threepane.ThreePane
@@ -97,14 +98,17 @@ fun PaneScaffoldState.PaneNavigationBar(
         enter = enterTransition,
         exit = exitTransition,
         content = {
-            if (canUseMovableNavigationBar) appState.movableNavigationBar(
-                Modifier,
-                onNavItemReselected,
-            )
-            else appState.PaneNavigationBar(
-                modifier = Modifier,
-                onNavItemReselected = onNavItemReselected,
-            )
+            with(displayScaffoldState) {
+                if (canUseMovableNavigationBar) displayScaffoldState.staticStates.movableNavigationBar(
+                    this,
+                    Modifier,
+                    onNavItemReselected,
+                )
+                else displayScaffoldState.PaneNavigationBar(
+                    modifier = Modifier,
+                    onNavItemReselected = onNavItemReselected,
+                )
+            }
         },
     )
 }
@@ -131,23 +135,26 @@ fun PaneScaffoldState.PaneNavigationRail(
         ) enterTransition else EnterTransition.None,
         exit = exitTransition,
         content = {
-            if (canUseMovableNavigationRail) appState.movableNavigationRail(
-                Modifier,
-                onNavItemReselected,
-            )
-            else appState.PaneNavigationRail(
-                modifier = Modifier,
-                onNavItemReselected = onNavItemReselected,
-            )
+            with(displayScaffoldState) {
+                if (canUseMovableNavigationRail) staticStates.movableNavigationRail(
+                    this,
+                    Modifier,
+                    onNavItemReselected,
+                )
+                else PaneNavigationRail(
+                    modifier = Modifier,
+                    onNavItemReselected = onNavItemReselected,
+                )
+            }
         },
     )
 }
 
 @Composable
-internal fun AppState.PaneNavigationBar(
+internal fun DisplayScaffoldState.PaneNavigationBar(
     modifier: Modifier = Modifier,
     onNavItemReselected: () -> Boolean,
-) {
+) = with(staticStates) {
     LookaheadScope {
         Surface(
             modifier = modifier
@@ -157,13 +164,17 @@ internal fun AppState.PaneNavigationBar(
                 ),
             color = BottomAppBarDefaults.containerColor.copy(alpha = BackgroundAlpha),
             contentColor = contentColorFor(BottomAppBarDefaults.containerColor),
-            shape = navigationBarShape(prefersCompactBottomNav),
+            shape = navigationBarShape(identityState.prefersCompactBottomNav),
         ) {
             Row(
                 modifier = Modifier
                     .navigationBarsPadding()
                     .fillMaxWidth()
-                    .height(UiTokens.bottomNavHeight(isCompact = prefersCompactBottomNav)),
+                    .height(
+                        UiTokens.bottomNavHeight(
+                            isCompact = identityState.prefersCompactBottomNav,
+                        ),
+                    ),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 navItems.forEach { item ->
@@ -197,17 +208,17 @@ internal fun AppState.PaneNavigationBar(
 }
 
 @Composable
-internal fun AppState.PaneNavigationRail(
+internal fun DisplayScaffoldState.PaneNavigationRail(
     modifier: Modifier = Modifier,
     onNavItemReselected: () -> Boolean,
-) {
+) = with(staticStates) {
     Box(
         modifier = modifier
             .padding(start = 8.dp)
             .fillMaxSize(),
     ) {
         val color by animateColorAsState(
-            if (LocalSplitPaneState.current.shouldElevateNavRail()) MaterialTheme.colorScheme.surfaceContainerHigh
+            if (shouldElevateNavRail()) MaterialTheme.colorScheme.surfaceContainerHigh
             else MaterialTheme.colorScheme.surface,
         )
         Column(
@@ -296,7 +307,7 @@ fun navigationBarShape(
 }
 
 @Composable
-private fun SplitPaneState.shouldElevateNavRail(): Boolean = remember(this) {
+private fun DisplayScaffoldState.shouldElevateNavRail(): Boolean = remember(this) {
     derivedStateOf {
         splitLayoutState.weightAt(0)
             .times(splitLayoutState.size)

--- a/ui/scaffold/src/commonMain/kotlin/com/tunjid/heron/ui/scaffold/scaffold/PaneNavigation.kt
+++ b/ui/scaffold/src/commonMain/kotlin/com/tunjid/heron/ui/scaffold/scaffold/PaneNavigation.kt
@@ -99,7 +99,7 @@ fun PaneScaffoldState.PaneNavigationBar(
         exit = exitTransition,
         content = {
             with(displayScaffoldState) {
-                if (canUseMovableNavigationBar) displayScaffoldState.staticStates.movableNavigationBar(
+                if (canUseMovableNavigationBar) staticStates.movableNavigationBar(
                     this,
                     Modifier,
                     onNavItemReselected,

--- a/ui/scaffold/src/commonMain/kotlin/com/tunjid/heron/ui/scaffold/scaffold/PaneScaffold.kt
+++ b/ui/scaffold/src/commonMain/kotlin/com/tunjid/heron/ui/scaffold/scaffold/PaneScaffold.kt
@@ -72,11 +72,11 @@ import com.tunjid.heron.ui.modifiers.blur
 import com.tunjid.heron.ui.modifiers.ifTrue
 import com.tunjid.heron.ui.scaffold.identity.isSignedIn
 import com.tunjid.heron.ui.scaffold.identity.isStable
+import com.tunjid.heron.ui.scaffold.identity.prefersAutoHidingBottomNav
+import com.tunjid.heron.ui.scaffold.identity.prefersCompactBottomNav
 import com.tunjid.heron.ui.scaffold.scaffold.components.NonSubComposingScaffold
 import com.tunjid.heron.ui.stateproduction.RouteViewModel
-import com.tunjid.heron.ui.stateproduction.RouteViewModelInitializer
-import com.tunjid.heron.ui.stateproduction.SheetViewModel
-import com.tunjid.heron.ui.stateproduction.SheetViewModelInitializer
+import com.tunjid.heron.ui.stateproduction.ViewModelInitializer
 import com.tunjid.heron.ui.stateproduction.viewModelCoroutineScope
 import com.tunjid.heron.ui.text.Memo
 import com.tunjid.heron.ui.text.message
@@ -85,7 +85,6 @@ import com.tunjid.treenav.compose.threepane.ThreePane
 import com.tunjid.treenav.compose.threepane.ThreePaneMovableElementSharedTransitionScope
 import com.tunjid.treenav.compose.threepane.rememberThreePaneMovableElementSharedTransitionScope
 import com.tunjid.treenav.strings.Route
-import kotlin.reflect.KClass
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
@@ -93,16 +92,17 @@ import kotlinx.coroutines.launch
 
 @Stable
 class PaneScaffoldState internal constructor(
-    internal val appState: AppState,
-    internal val splitPaneState: SplitPaneState,
+    internal val displayScaffoldState: DisplayScaffoldState,
+    viewModelInitializer: ViewModelInitializer,
     paneMovableElementSharedTransitionScope: ThreePaneMovableElementSharedTransitionScope<Route>,
 ) : PaneTransitionScope,
+    ViewModelInitializer by viewModelInitializer,
     ThreePaneMovableElementSharedTransitionScope<Route> by paneMovableElementSharedTransitionScope {
 
     override val childBoundsTransform: BoundsTransform = { _, _ ->
         BoundsTransformSpring.skipIf {
-            appState.dismissBehavior is AppState.DismissBehavior.Gesture.DragToPop ||
-                splitPaneState.paneAnchorState.hasInteractions
+            displayScaffoldState.dismissBehavior is DisplayScaffoldState.DismissBehavior.Gesture.DragToPop ||
+                displayScaffoldState.paneAnchorState.hasInteractions
         }
     }
 
@@ -111,48 +111,22 @@ class PaneScaffoldState internal constructor(
     internal val snackbarMessages = mutableStateListOf<Memo>()
 
     val isMediumScreenWidthOrWider: Boolean
-        get() = splitPaneState.isMediumScreenWidthOrWider
+        get() = displayScaffoldState.isMediumScreenWidthOrWider
 
-    val dismissBehavior: AppState.DismissBehavior
-        get() = appState.dismissBehavior
+    internal val dismissBehavior: DisplayScaffoldState.DismissBehavior
+        get() = displayScaffoldState.dismissBehavior
 
     val isSignedOut
-        get() = !appState.identityState.isSignedIn
+        get() = !displayScaffoldState.staticStates.identityState.isSignedIn
 
     val isSignedIn
-        get() = appState.identityState.isSignedIn
+        get() = displayScaffoldState.staticStates.identityState.isSignedIn
 
     val prefersCompactBottomNav
-        get() = appState.prefersCompactBottomNav
-
-    /**
-     * Resolves the [SheetViewModelInitializer] for [modelClass] from the app graph. This is the
-     * single entry point through which the `ui:sheets` module reaches the sheet ViewModel
-     * factories held by [AppState], without the scaffold layer depending on that module.
-     */
-    fun sheetViewModelInitializer(
-        modelClass: KClass<out SheetViewModel>,
-    ): SheetViewModelInitializer =
-        appState.sheetViewModelInitializers[modelClass]
-            ?: throw IllegalStateException(
-                "No SheetViewModelInitializer registered for ${modelClass.simpleName}. Ensure it is contributed in SheetBindings.",
-            )
-
-    /**
-     * Resolves the [RouteViewModelInitializer] for [modelClass] from the app graph. Together with
-     * [rememberRouteViewModel] this makes [PaneScaffoldState] the only dependency needed to create a
-     * screen's ViewModel; each feature contributes its initializer in its own `Bindings`.
-     */
-    fun routeViewModelInitializer(
-        modelClass: KClass<out RouteViewModel>,
-    ): RouteViewModelInitializer =
-        appState.routeViewModelInitializers[modelClass]
-            ?: throw IllegalStateException(
-                "No RouteViewModelInitializer registered for ${modelClass.simpleName}. Ensure it is contributed in the feature's Bindings.",
-            )
+        get() = displayScaffoldState.staticStates.identityState.prefersCompactBottomNav
 
     val prefersAutoHidingBottomNav
-        get() = appState.prefersAutoHidingBottomNav
+        get() = displayScaffoldState.staticStates.identityState.prefersAutoHidingBottomNav
 
     internal val nestedNavigationState = PaneNestedNavigationState(
         paneScaffoldState = this,
@@ -165,7 +139,7 @@ class PaneScaffoldState internal constructor(
         get() = isActive && canShowNavigationBar
 
     internal val canShowNavigationRail: Boolean
-        get() = splitPaneState.filteredPaneOrder.firstOrNull() == paneState.pane &&
+        get() = displayScaffoldState.filteredPaneOrder.firstOrNull() == paneState.pane &&
             isMediumScreenWidthOrWider
 
     internal val canUseMovableNavigationRail: Boolean
@@ -213,19 +187,19 @@ inline fun <reified VM : RouteViewModel> PaneScaffoldState.rememberRouteViewMode
 }
 
 @Composable
-fun PaneScope<ThreePane, Route>.rememberPaneScaffoldState(): PaneScaffoldState {
-    val appState = LocalAppState.current
-    val splitPaneState = LocalSplitPaneState.current
-    val paneMovableElementSharedTransitionScope =
-        rememberThreePaneMovableElementSharedTransitionScope()
+fun PaneScope<ThreePane, Route>.rememberPaneScaffoldState(
+    displayScaffoldState: DisplayScaffoldState = LocalDisplayScaffoldState.current,
+    viewModelInitializer: ViewModelInitializer = LocalAppState.current.viewModelInitializer,
+    paneMovableElementSharedTransitionScope: ThreePaneMovableElementSharedTransitionScope<Route> = rememberThreePaneMovableElementSharedTransitionScope(),
+): PaneScaffoldState {
     val paneScaffoldState = remember(
-        appState,
-        splitPaneState,
+        displayScaffoldState,
+        viewModelInitializer,
         paneMovableElementSharedTransitionScope,
     ) {
         PaneScaffoldState(
-            appState = appState,
-            splitPaneState = splitPaneState,
+            displayScaffoldState = displayScaffoldState,
+            viewModelInitializer = viewModelInitializer,
             paneMovableElementSharedTransitionScope = paneMovableElementSharedTransitionScope,
         )
     }
@@ -288,17 +262,17 @@ fun PaneScaffoldState.PaneScaffold(
         content = {
             NonSubComposingScaffold(
                 modifier = when {
-                    splitPaneState.paneAnchorState.hasInteractions -> Modifier
+                    displayScaffoldState.paneAnchorState.hasInteractions -> Modifier
                     else -> when (dismissBehavior) {
-                        AppState.DismissBehavior.None,
-                        AppState.DismissBehavior.Gesture.DragToPop,
+                        DisplayScaffoldState.DismissBehavior.None,
+                        DisplayScaffoldState.DismissBehavior.Gesture.DragToPop,
                         -> Modifier.animateBounds(
                             lookaheadScope = this,
                             boundsTransform = childBoundsTransform,
                         )
 
-                        AppState.DismissBehavior.Gesture.SlideToPop,
-                        AppState.DismissBehavior.Gesture.ScaleToPop,
+                        DisplayScaffoldState.DismissBehavior.Gesture.SlideToPop,
+                        DisplayScaffoldState.DismissBehavior.Gesture.ScaleToPop,
                         -> Modifier
                     }
                 },
@@ -316,7 +290,7 @@ fun PaneScaffoldState.PaneScaffold(
                     snackBarHost()
                 },
                 content = { paddingValues ->
-                    val isStable = appState.identityState.isStable
+                    val isStable = displayScaffoldState.staticStates.identityState.isStable
                     val blurState = animateFloatAsState(
                         if (isStable) 0f else 1f,
                     )
@@ -339,7 +313,7 @@ fun PaneScaffoldState.PaneScaffold(
                             )
                             .constrainedSizePlacement(
                                 orientation = Orientation.Horizontal,
-                                minSize = splitPaneState.minPaneWidth,
+                                minSize = displayScaffoldState.minPaneWidth,
                                 atStart = paneState.pane == ThreePane.Secondary,
                             ),
                     ) {
@@ -358,7 +332,7 @@ fun PaneScaffoldState.PaneScaffold(
 
     if (paneState.pane == ThreePane.Primary) {
         LaunchedEffect(showNavigation) {
-            appState.showNavigation = showNavigation
+            displayScaffoldState.showNavigation = showNavigation
         }
     }
 }

--- a/ui/scaffold/src/commonMain/kotlin/com/tunjid/heron/ui/scaffold/scaffold/PaneTopAppBar.kt
+++ b/ui/scaffold/src/commonMain/kotlin/com/tunjid/heron/ui/scaffold/scaffold/PaneTopAppBar.kt
@@ -127,13 +127,13 @@ fun PaneScaffoldState.RootDestinationTopAppBar(
     onSignedInProfileClicked: (Profile, String) -> Unit,
     onLogoClicked: (() -> Unit)? = null,
 ) {
-    val identityState = appState.identityState
+    val identityState = displayScaffoldState.staticStates.identityState
     ClickPassThroughToolbar(
         modifier = modifier
             .constrainedSizePlacement(
                 orientation = Orientation.Horizontal,
-                minSize = splitPaneState.minPaneWidth,
-                atStart = splitPaneState.filteredPaneOrder.firstOrNull() == paneState.pane,
+                minSize = displayScaffoldState.minPaneWidth,
+                atStart = displayScaffoldState.filteredPaneOrder.firstOrNull() == paneState.pane,
             )
             .rootAppBarBackground(
                 backgroundColor = MaterialTheme.colorScheme.surface,
@@ -154,7 +154,7 @@ fun PaneScaffoldState.RootDestinationTopAppBar(
                     modifier = Modifier
                         .padding(4.dp)
                         .then(
-                            if (onLogoClicked != null && appState.identityState.isStable) {
+                            if (onLogoClicked != null && identityState.isStable) {
                                 Modifier.shapedClickable(
                                     CircleShape,
                                     onClick = onLogoClicked,
@@ -211,14 +211,14 @@ fun PaneScaffoldState.RootDestinationTopAppBar(
                             signedInProfileId = identityState.signedInProfile?.did,
                             onLongClick = {
                                 if (identityState.pastSessions.isNotEmpty() && identityState.isStable)
-                                    appState.onIdentityAction(
-                                        IdentityAction.Switch.Choose,
+                                    displayScaffoldState.staticStates.onIdentityAction(
+                                        action = IdentityAction.Switch.Choose,
                                     )
                             },
                             onClick = {
                                 when (identityState.switchStatus) {
-                                    IdentityState.SwitchStatus.Choosing -> appState.onIdentityAction(
-                                        IdentityAction.Switch.Transition(sessionSummary),
+                                    IdentityState.SwitchStatus.Choosing -> displayScaffoldState.staticStates.onIdentityAction(
+                                        action = IdentityAction.Switch.Transition(sessionSummary),
                                     )
                                     is IdentityState.SwitchStatus.Stable -> identityState.signedInProfile?.let { profile ->
                                         onSignedInProfileClicked(
@@ -240,7 +240,9 @@ fun PaneScaffoldState.RootDestinationTopAppBar(
             ) {
                 AppBarIconButton(
                     onClick = {
-                        appState.onIdentityAction(IdentityAction.Switch.Cancel)
+                        displayScaffoldState.staticStates.onIdentityAction(
+                            action = IdentityAction.Switch.Cancel,
+                        )
                     },
                     colors = CardDefaults.elevatedCardColors(
                         containerColor = Color.Transparent,
@@ -270,8 +272,8 @@ fun PaneScaffoldState.PoppableDestinationTopAppBar(
         modifier = modifier
             .constrainedSizePlacement(
                 orientation = Orientation.Horizontal,
-                minSize = splitPaneState.minPaneWidth,
-                atStart = splitPaneState.filteredPaneOrder.firstOrNull() == paneState.pane,
+                minSize = displayScaffoldState.minPaneWidth,
+                atStart = displayScaffoldState.filteredPaneOrder.firstOrNull() == paneState.pane,
             )
             .renderInSharedTransitionScopeOverlay(
                 zIndexInOverlay = UiTokens.appBarSharedElementZIndex,
@@ -327,7 +329,7 @@ private fun PaneScaffoldState.SwitchStatus(
                         contentDescription = description
                         role = Role.Button
                     },
-                onClick = appState::addAccount,
+                onClick = displayScaffoldState::addAccount,
                 content = {
                     Icon(
                         imageVector = Icons.Rounded.Error,
@@ -348,7 +350,7 @@ private fun PaneScaffoldState.SwitchStatus(
                         contentDescription = description
                         role = Role.Button
                     },
-                onClick = appState::addAccount,
+                onClick = displayScaffoldState::addAccount,
                 content = {
                     Icon(
                         imageVector = Icons.Rounded.Add,
@@ -465,8 +467,7 @@ private fun PaneScaffoldState.OfflineIcon(
 private fun PaneScaffoldState.FailedWriteIcon(
     modifier: Modifier = Modifier,
 ) {
-    val appState = LocalAppState.current
-    val failedWrite = appState.identityState.lastFailedWrite ?: return
+    val failedWrite = displayScaffoldState.staticStates.identityState.lastFailedWrite ?: return
     val description = remember(failedWrite) { failedWrite.writable.describe() }
     NavigationIconPopoverButton(
         modifier = modifier,
@@ -499,14 +500,18 @@ private fun PaneScaffoldState.FailedWriteIcon(
                 FilledTonalButton(
                     onClick = {
                         onClose()
-                        appState.onNavigateToTasks()
+                        displayScaffoldState.onNavigateToTasks()
                     },
                 ) {
                     Text(text = stringResource(Res.string.failed_write_view_details))
                 }
             }
             DisposableEffect(Unit) {
-                onDispose { appState.onIdentityAction(IdentityAction.ClearFailedWrite) }
+                onDispose {
+                    displayScaffoldState.staticStates.onIdentityAction(
+                        action = IdentityAction.ClearFailedWrite,
+                    )
+                }
             }
         },
     )
@@ -522,7 +527,7 @@ private fun PaneScaffoldState.NavigationIconBox(
     ) {
         content()
 
-        val identityState = LocalAppState.current.identityState
+        val identityState = displayScaffoldState.staticStates.identityState
 
         Box(
             modifier = Modifier

--- a/ui/scaffold/src/commonMain/kotlin/com/tunjid/heron/ui/scaffold/scaffold/PredictiveBack.kt
+++ b/ui/scaffold/src/commonMain/kotlin/com/tunjid/heron/ui/scaffold/scaffold/PredictiveBack.kt
@@ -37,7 +37,7 @@ fun Modifier.predictiveBackPlacement(
     val shouldDrawBackground = paneState.pane == ThreePane.Primary &&
         inPredictiveBack &&
         isActive &&
-        appState.dismissBehavior != AppState.DismissBehavior.Gesture.DragToPop
+        displayScaffoldState.dismissBehavior != DisplayScaffoldState.DismissBehavior.Gesture.DragToPop
 
     ifTrue(shouldDrawBackground) {
         backPreview(backPreviewState)


### PR DESCRIPTION
Restructure's app level state holders to allow for configuring `PaneScaffoldState`. This allows for replacing `PaneScaffoldState` constructor arguments, allowing for previews and UI testing.