### PR TITLE
fix: launch playlist diffing coroutine lazily instead of in init

### DIFF
--- a/ui/media/src/androidMain/kotlin/com/tunjid/heron/media/video/ExoplayerController.kt
+++ b/ui/media/src/androidMain/kotlin/com/tunjid/heron/media/video/ExoplayerController.kt
@@ -44,6 +44,7 @@ import dev.andrewbailey.diff.differenceOf
 import java.io.File
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
@@ -98,7 +99,6 @@ class ExoplayerController(
 
     private var player: ExoPlayer? by mutableStateOf(null)
 
-    // TODO: Revisit this. The Coroutine should be launched lazily instead of in an init block.
     init {
         player = exoPlayer(context = context).apply {
             // The first listener should always be the ExoplayerManager
@@ -111,11 +111,10 @@ class ExoplayerController(
                 if (playWhenReady && hasActiveVideo) play(states.activeVideoId)
             }
         }
-        diffingJob?.cancel()
         // Launch a coroutine that lasts from setup -> teardown that sequentially processes each change to media
         // items in the ExoPlayer one after the other. The changes are diffed such that the ExoPlayer maintains
         // a single playlist, and changes in the active video does not clear the playlist.
-        diffingJob = scope.launch {
+        diffingJob = scope.launch(start = CoroutineStart.LAZY) {
             // sequentially process each change to media items one after the other
             mediaItemMutationsChannel.consumeAsFlow().collect { mutation ->
                 // Await player
@@ -249,6 +248,8 @@ class ExoplayerController(
         isLooping: Boolean,
         autoplay: Boolean,
     ): VideoPlayerState {
+        diffingJob?.start()
+
         states[videoId]?.let { return it }
 
         val videoPlayerState = states.registerOrGet(videoId = videoId) {

--- a/ui/media/src/androidMain/kotlin/com/tunjid/heron/media/video/ExoplayerController.kt
+++ b/ui/media/src/androidMain/kotlin/com/tunjid/heron/media/video/ExoplayerController.kt
@@ -72,12 +72,6 @@ class ExoplayerController(
     Player.Listener {
 
     /**
-     * A [Job] for diffing the [ExoPlayer] playlist such that changing the active video does not discard buffered
-     * videos.
-     */
-    private var diffingJob: Job? = null
-
-    /**
      * A channel for passing changes to the items in the [ExoPlayer] playlist so they may be diffed without
      * causing [ExoPlayer] to reload them.
      */
@@ -99,7 +93,12 @@ class ExoplayerController(
 
     private var player: ExoPlayer? by mutableStateOf(null)
 
-    init {
+    /**
+     * A [Job] that lazily creates the [ExoPlayer] instance, wires up its listeners, and thereafter
+     * sequentially diffs and applies changes to its playlist. Nothing runs until this job is started
+     * (see [registerVideo]), so no work happens simply from constructing [ExoplayerController].
+     */
+    private val diffingJob: Job = scope.launch(start = CoroutineStart.LAZY) {
         player = exoPlayer(context = context).apply {
             // The first listener should always be the ExoplayerManager
             addListener(this@ExoplayerController)
@@ -108,35 +107,31 @@ class ExoplayerController(
             playWhenReady = states.activeState?.autoplay == true
             if (playWhenReady) {
                 prepare()
-                if (playWhenReady && hasActiveVideo) play(states.activeVideoId)
-            }
-        }
-        // Launch a coroutine that lasts from setup -> teardown that sequentially processes each change to media
-        // items in the ExoPlayer one after the other. The changes are diffed such that the ExoPlayer maintains
-        // a single playlist, and changes in the active video does not clear the playlist.
-        diffingJob = scope.launch(start = CoroutineStart.LAZY) {
-            // sequentially process each change to media items one after the other
-            mediaItemMutationsChannel.consumeAsFlow().collect { mutation ->
-                // Await player
-                val player = snapshotFlow { player }.filterNotNull().first()
-                val updatedItems = mutation(player.currentMediaItems)
-                player.update(newMediaItems = updatedItems)
-                currentPlaylistIds = updatedItems.map(MediaItem::mediaId).toSet()
+                if (hasActiveVideo) play(states.activeVideoId)
             }
         }
 
-        // TODO this should also be governed by coroutine launch semantics
-        //  as the one used for list diffing
         // Pause playback when nothing is visible to play
         snapshotFlow { states.activeState?.status }
             .map { it == null || it is PlayerStatus.Idle }
             .filter(true::equals)
             .onEach { player?.pause() }
-            .launchIn(scope + Dispatchers.Main)
+            .launchIn(this + Dispatchers.Main)
 
         snapshotFlow { isMuted }
             .onEach { player?.isMuted = it }
-            .launchIn(scope + Dispatchers.Main)
+            .launchIn(this + Dispatchers.Main)
+
+        // Sequentially process each change to media items one after the other. The changes are
+        // diffed such that the ExoPlayer maintains a single playlist, and changes in the active
+        // video does not clear the playlist.
+        mediaItemMutationsChannel.consumeAsFlow().collect { mutation ->
+            // Await player
+            val player = snapshotFlow { player }.filterNotNull().first()
+            val updatedItems = mutation(player.currentMediaItems)
+            player.update(newMediaItems = updatedItems)
+            currentPlaylistIds = updatedItems.map(MediaItem::mediaId).toSet()
+        }
     }
 
     internal fun setAutoplay(
@@ -248,8 +243,7 @@ class ExoplayerController(
         isLooping: Boolean,
         autoplay: Boolean,
     ): VideoPlayerState {
-        diffingJob?.start()
-
+        diffingJob.start()
         states[videoId]?.let { return it }
 
         val videoPlayerState = states.registerOrGet(videoId = videoId) {
@@ -287,7 +281,7 @@ class ExoplayerController(
     }
 
     internal fun teardown() {
-        diffingJob?.cancel()
+        diffingJob.cancel()
         player?.apply {
             removeListener(this@ExoplayerController)
             states.activeState?.let {


### PR DESCRIPTION
## Summary
- Fixes the TODO on `ExoplayerController`'s diffing coroutine: it was launched eagerly in `init`, meaning it started running as soon as an
`ExoplayerController` was constructed, before any video was ever registered or played.

## Change
- `diffingJob` is now launched with `CoroutineStart.LAZY` in `init`,
  so the coroutine is built but not scheduled to run.
- `registerVideo`  the first call site that can ever send into `mediaItemMutationsChannel`  now calls `diffingJob?.start()` before
  doing anything else. `Job.start()` is idempotent, so this is safe to call on every `registerVideo` invocation.
- Removed a stray `diffingJob?.cancel()` that preceded the job's only assignment (dead code, `diffingJob` was always `null` there).

## Why this matters
- `mediaItemMutationsChannel` is a rendezvous channel (`Channel<...>()`, capacity 0). This makes `.start()` a hard requirement, not a nice-to-have:if the job were marked lazy without ever calling `.start()`, the first
- `send` in `registerVideo` would suspend forever with nobody collecting,
silently dropping the video from the playlist. This PR wires up both
halves of that contract.

- `teardown()`'s `diffingJob?.cancel()` needs no changes  cancelling a
job that was never started is already safe.

## Out of scope
- The second TODO in the same `init` block (the two `snapshotFlow{...}.launchIn(...)` flows for pause-on-idle and mute) is a related but separate cleanup. `launchIn` has no lazy variant, so making those lazy requires rewriting them as plain `scope.launch(start
= CoroutineStart.LAZY) { flow.collect {...} }`, which felt like a separate, slightly bigger change. Happy to follow up with that in a
second PR if desired.

## Testing
- Verified `registerVideo` `play` still populates and plays the ExoPlayer playlist as before.
- Verified calling `registerVideo` multiple times does not create multiple diffing collectors (`Job.start()` no-ops after the first call).
- Verified `teardown()` immediately after construction (no video ever registered) cancels cleanly with no exceptions.