### PR TITLE
Fix New Post Notification not appearing in app even if the icon shows it in the bottom menu

### DIFF
--- a/data/core/src/commonMain/kotlin/com/tunjid/heron/data/utilities/multipleEntitysaver/SaveListNotification.kt
+++ b/data/core/src/commonMain/kotlin/com/tunjid/heron/data/utilities/multipleEntitysaver/SaveListNotification.kt
@@ -98,6 +98,6 @@ internal fun ListNotificationsNotification.associatedPostUri(): AtUri? = when (r
     ListNotificationsNotificationReason.Verified -> null
     ListNotificationsNotificationReason.LikeViaRepost -> record.safeDecodeAs<Like>()?.subject?.uri
     ListNotificationsNotificationReason.RepostViaRepost -> record.safeDecodeAs<Repost>()?.subject?.uri
-    ListNotificationsNotificationReason.SubscribedPost -> reasonSubject
+    ListNotificationsNotificationReason.SubscribedPost -> uri
     ListNotificationsNotificationReason.ContactMatch -> null
 }


### PR DESCRIPTION
Subscribed post notifications never appear in the notifications list, even though the nav badge counts them.

## Root Cause

`associatedPostUri()` resolved the subject post for `subscribed-post` from `reasonSubject`. Bluesky does not populate `reasonSubject` for that reason: the notification record *is* the post, so the subject lives at `notification.uri`, exactly like `reply`, `mention` and `quote` already do in the same `when`. 

```ts
if (type === 'reply' || type === 'quote' || type === 'mention' || type === 'subscribed-post') { return notif.uri }
```

## Testing

Verified on the JVM desktop app against a live account with an activity subscription. Before the change the notifications list showed nothing while the badge showed a count; after a pull to refresh the subscribed post renders as a `SubscribedRow`.

Not covered: `getUnreadCount` exposes no per reason breakdown, so there is no way to assert the badge and the list agree other than by eye.
